### PR TITLE
Add line number option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # grepdef
 
-Usage: grepdef [options] <symbol> [path]
+Usage: grepdef [options] &lt;symbol&gt; [path]
 
 The symbol is the full string name of a class, function, variable, or similar construct.
 
@@ -14,7 +14,7 @@ The output is like using grep, but will only show places where that symbol is de
 
 ## CLI Options
 
--t, --type <TYPE>
+-t, --type &lt;TYPE&gt;
 
 The type is a vim-compatible filetype. One of 'js', 'php', or an alias for those strings (eg: 'javascript.jsx'). Typescript is currently considered part of JavaScript so a type of 'typescript' is equivalent to 'js'.
 
@@ -24,11 +24,11 @@ If the type is not provided, grepdef will try to guess the filetype, but this ma
 
 Show line numbers (1-based).
 
---searcher <SEARCHER>
+--searcher &lt;SEARCHER&gt;
 
 Use the specified searcher. Currently only 'ripgrep' is supported.
 
---reporter <REPORTER>
+--reporter &lt;REPORTER&gt;
 
 Use the specified reporter. Currently only 'human' is supported.
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,6 @@
 # grepdef
 
-A cli tool to search for symbol definitions in various programming languages
-
-Usage: grepdef [--type &lt;type&gt;] &lt;symbol&gt; [path]
-
-The type is a vim-compatible filetype. One of 'js', 'php', or an alias for those strings (eg: 'javascript.jsx'). Typescript is currently considered part of JavaScript so a type of 'typescript' is equivalent to 'js'.
-
-If the type is not provided, grepdef will try to guess the filetype, but this may be inaccurate.
+Usage: grepdef [options] <symbol> [path]
 
 The symbol is the full string name of a class, function, variable, or similar construct.
 
@@ -14,7 +8,37 @@ The path is a relative or absolute file path to a file or a directory or a space
 
 If a search path is not provided, this will search starting from the current directory.
 
-The output is like using grep, but will only show places where that symbol is defined (no partial matches, variable uses, or function calls). The search uses a regular expression so it is unaware of scope and is far from fullproof, but should be easier than a grep by itself.
+You should use the `--type` option whenever possible, but grepdef will try to guess the type if it is not set.
+
+The output is like using grep, but will only show places where that symbol is defined (no partial matches, variable uses, or function calls). The search uses a regular expression so it is unaware of scope and is far from fullproof, but should be easier and faster than a grep by itself.
+
+## CLI Options
+
+-t, --type <TYPE>
+
+The type is a vim-compatible filetype. One of 'js', 'php', or an alias for those strings (eg: 'javascript.jsx'). Typescript is currently considered part of JavaScript so a type of 'typescript' is equivalent to 'js'.
+
+If the type is not provided, grepdef will try to guess the filetype, but this may be inaccurate.
+
+-n, --line-number
+
+Show line numbers (1-based).
+
+--searcher <SEARCHER>
+
+Use the specified searcher. Currently only 'ripgrep' is supported.
+
+--reporter <REPORTER>
+
+Use the specified reporter. Currently only 'human' is supported.
+
+--no-color
+
+Disable colors in reporters that support them.
+
+-h, --help
+
+Print this help text.
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ Disable colors in reporters that support them.
 
 Print this help text.
 
+-v, --version
+
+Print the version information.
+
 ## Example
 
 ```

--- a/index.js
+++ b/index.js
@@ -2,6 +2,11 @@
 
 const minimist = require('minimist');
 const { searchAndReport, normalizeType } = require('./src/general.js');
+var packageJson = require('./package.json');
+
+function printVersion() {
+	console.log(`grepdef ${packageJson.version}`);
+}
 
 function printHelp() {
 	const helpText = `
@@ -57,6 +62,10 @@ Options:
 -h, --help
 
   Print this help text.
+
+-v, --version
+
+  Print the version information.
 `;
 	console.log(helpText);
 }
@@ -64,7 +73,7 @@ Options:
 async function grepdef(args) {
 	const options = minimist(args, {
 		string: ['type', 'searcher', 'reporter'],
-		boolean: ['n', 'line-number', 'help', 'h', 'no-color'],
+		boolean: ['n', 'line-number', 'help', 'h', 'no-color', 'v', 'version'],
 	});
 	const langType = options.type;
 	const searchTool = options.searcher || 'ripgrep';
@@ -75,6 +84,10 @@ async function grepdef(args) {
 	const path = options._.slice(1).join(' ') || '.';
 	if (options.h || options.help) {
 		printHelp();
+		process.exit(0);
+	}
+	if (options.v || options.version) {
+		printVersion();
 		process.exit(0);
 	}
 	if (!searchSymbol) {

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ function printHelp() {
 	const helpText = `
 grepdef: search for symbol definitions in various programming languages
 
-Usage: grepdef [--type <type>] [OPTIONS] <symbol> [path]
+Usage: grepdef [options] <symbol> [path]
 
 The symbol is the full string name of a class, function, variable, or similar
 construct.
@@ -19,36 +19,45 @@ shell will turn into paths.
 If a search path is not provided, this will search starting from the current
 directory.
 
+You should use the '--type' option whenever possible, but grepdef will try to
+guess the type if it is not set.
+
 The output is like using grep, but will only show places where that symbol is
 defined (no partial matches, variable uses, or function calls). The search uses
 a regular expression so it is unaware of scope and is far from fullproof, but
-should be easier than a grep by itself.
+should be easier and faster than a grep by itself.
 
-OPTIONS:
+Options:
 
-	-t, --type <TYPE>
-		The type is a vim-compatible filetype. One of 'js', 'php', or an alias for
-		those strings (eg: 'javascript.jsx'). Typescript is currently considered part
-		of JavaScript so a type of 'typescript' is equivalent to 'js'.
+-t, --type <TYPE>
 
-		If the type is not provided, grepdef will try to guess the filetype, but this
-		may be inaccurate.
+  The type is a vim-compatible filetype. One of 'js', 'php', or an alias for
+  those strings (eg: 'javascript.jsx'). Typescript is currently considered part
+  of JavaScript so a type of 'typescript' is equivalent to 'js'.
 
-	-n, --line-number
-		Show line numbers (1-based).
+  If the type is not provided, grepdef will try to guess the filetype, but this
+  may be inaccurate.
 
-	--searcher <SEARCHER>
-		Use the specified searcher. Currently only 'ripgrep' is supported.
+-n, --line-number
 
-	--reporter <REPORTER>
-		Use the specified reporter. Currently only 'human' is supported.
+  Show line numbers (1-based).
 
-	--no-color
-		Disable colors in reporters that support them.
+--searcher <SEARCHER>
 
-	-h, --help
-		Print this help text.
-	`;
+  Use the specified searcher. Currently only 'ripgrep' is supported.
+
+--reporter <REPORTER>
+
+  Use the specified reporter. Currently only 'human' is supported.
+
+--no-color
+
+  Disable colors in reporters that support them.
+
+-h, --help
+
+  Print this help text.
+`;
 	console.log(helpText);
 }
 

--- a/index.js
+++ b/index.js
@@ -43,6 +43,9 @@ OPTIONS:
 	--reporter <REPORTER>
 		Use the specified reporter. Currently only 'human' is supported.
 
+	--no-color
+		Disable colors in reporters that support them.
+
 	-h, --help
 		Print this help text.
 	`;
@@ -52,12 +55,13 @@ OPTIONS:
 async function grepdef(args) {
 	const options = minimist(args, {
 		string: ['type', 'searcher', 'reporter'],
-		boolean: ['n', 'line-number', 'help', 'h'],
+		boolean: ['n', 'line-number', 'help', 'h', 'no-color'],
 	});
 	const langType = options.type;
 	const searchTool = options.searcher || 'ripgrep';
 	const reporterName = options.reporter || 'human';
 	const showLineNumbers = options.n || options['line-number'];
+	const disableColor = options['no-color'];
 	const searchSymbol = options._[0];
 	const path = options._.slice(1).join(' ') || '.';
 	if (options.h || options.help) {
@@ -77,6 +81,7 @@ async function grepdef(args) {
 			searchTool,
 			path,
 			showLineNumbers,
+			disableColor,
 		},
 		reporterName
 	).catch(error => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@sirbrillig/grepdef",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/general.js
+++ b/src/general.js
@@ -26,7 +26,7 @@ const readdir = util.promisify(fs.readdir);
  */
 
 /**
- * @typedef {(arg: SearchResult[]) => void} ReporterFunction
+ * @typedef {(arg: SearchResult[], config: SearchConfig) => void} ReporterFunction
  */
 
 /**
@@ -36,7 +36,8 @@ const readdir = util.promisify(fs.readdir);
 /**
  * @typedef {object} SearchConfig
  * @property {FileType|null} type
- * @property {boolean} [verbose]
+ * @property {boolean} verbose
+ * @property {boolean} showLineNumbers
  * @property {SearchTool} searchTool
  * @property {Glob} path
  */
@@ -54,10 +55,10 @@ const readdir = util.promisify(fs.readdir);
  * @param {ReporterType} reporterName
  * @returns void
  */
-async function searchAndReport(symbol, { type, verbose, searchTool, path }, reporterName) {
-	const results = await search(symbol, { type, verbose, searchTool, path });
+async function searchAndReport(symbol, config, reporterName) {
+	const results = await search(symbol, config);
 	const reporter = getReporterForReporterName(reporterName);
-	reporter(results);
+	reporter(results, config);
 }
 
 /**
@@ -65,13 +66,13 @@ async function searchAndReport(symbol, { type, verbose, searchTool, path }, repo
  * @param {SearchConfig} config
  * @returns {Promise<SearchResult[]>}
  */
-async function search(symbol, { type, verbose, searchTool, path }) {
+async function search(symbol, { type, searchTool, path, ...otherOptions }) {
 	if (!type) {
 		type = await guessType(path);
 	}
 	const regexp = getRegexpForType(symbol, type);
 	const searcher = getSearchToolForSearcherName(searchTool);
-	return searcher(regexp, { type, verbose, searchTool, path });
+	return searcher(regexp, { type, searchTool, path, ...otherOptions });
 }
 
 /**

--- a/src/general.js
+++ b/src/general.js
@@ -26,7 +26,7 @@ const readdir = util.promisify(fs.readdir);
  */
 
 /**
- * @typedef {(arg: SearchResult[], config: SearchConfig) => void} ReporterFunction
+ * @typedef {(arg: SearchResult[], config: SearchConfig) => string[]} ReporterFunction
  */
 
 /**
@@ -58,7 +58,8 @@ const readdir = util.promisify(fs.readdir);
 async function searchAndReport(symbol, config, reporterName) {
 	const results = await search(symbol, config);
 	const reporter = getReporterForReporterName(reporterName);
-	reporter(results, config);
+	const output = reporter(results, config);
+	output.forEach(result => console.log(result));
 }
 
 /**
@@ -189,4 +190,5 @@ module.exports = {
 	search,
 	searchAndReport,
 	normalizeType,
+	getReporterForReporterName,
 };

--- a/src/general.js
+++ b/src/general.js
@@ -38,6 +38,7 @@ const readdir = util.promisify(fs.readdir);
  * @property {FileType|null} type
  * @property {boolean} verbose
  * @property {boolean} showLineNumbers
+ * @property {boolean} disableColor
  * @property {SearchTool} searchTool
  * @property {Glob} path
  */

--- a/src/reporters/human.js
+++ b/src/reporters/human.js
@@ -1,18 +1,19 @@
 // @ts-check
 
-const chalk = require('chalk');
+const chalk = require('chalk').default;
 
 /**
  * @param {import('../searchers/ripgrep').SearchResult[]} results
  * @param {import('../general').SearchConfig} config
  * @return {string[]}
  */
-function outputResults(results, {showLineNumbers}) {
+function outputResults(results, { showLineNumbers, disableColor }) {
+	const ctx = disableColor ? new chalk.constructor({ level: 0 }) : chalk;
 	return results.map(match => {
 		if (showLineNumbers) {
-			return `${chalk.default.magenta(match.path)}:${chalk.default.green(String(match.line))}:${match.text}`;
+			return `${ctx.magenta(match.path)}:${ctx.green(String(match.line))}:${match.text}`;
 		}
-		return `${chalk.default.magenta(match.path)}:${match.text}`;
+		return `${ctx.magenta(match.path)}:${match.text}`;
 	});
 }
 

--- a/src/reporters/human.js
+++ b/src/reporters/human.js
@@ -5,16 +5,15 @@ const chalk = require('chalk');
 /**
  * @param {import('../searchers/ripgrep').SearchResult[]} results
  * @param {import('../general').SearchConfig} config
- * @return void
+ * @return {string[]}
  */
 function outputResults(results, {showLineNumbers}) {
-	const messages = results.map(match => {
+	return results.map(match => {
 		if (showLineNumbers) {
 			return `${chalk.default.magenta(match.path)}:${chalk.default.green(String(match.line))}:${match.text}`;
 		}
 		return `${chalk.default.magenta(match.path)}:${match.text}`;
 	});
-	messages.map(message => console.log(message));
 }
 
 module.exports = outputResults;

--- a/src/reporters/human.js
+++ b/src/reporters/human.js
@@ -1,15 +1,18 @@
-// @format
 // @ts-check
 
 const chalk = require('chalk');
 
 /**
  * @param {import('../searchers/ripgrep').SearchResult[]} results
+ * @param {import('../general').SearchConfig} config
  * @return void
  */
-function outputResults(results) {
+function outputResults(results, {showLineNumbers}) {
 	const messages = results.map(match => {
-		return `${chalk.default.magenta(match.path)}:${chalk.default.green(String(match.line))}:${match.text}`;
+		if (showLineNumbers) {
+			return `${chalk.default.magenta(match.path)}:${chalk.default.green(String(match.line))}:${match.text}`;
+		}
+		return `${chalk.default.magenta(match.path)}:${match.text}`;
 	});
 	messages.map(message => console.log(message));
 }

--- a/src/searchers/ripgrep.js
+++ b/src/searchers/ripgrep.js
@@ -1,4 +1,3 @@
-// @format
 // @ts-check
 
 const util = require('util');

--- a/tests/normalize-type.test.js
+++ b/tests/normalize-type.test.js
@@ -1,3 +1,4 @@
+// @ts-check
 const { normalizeType } = require('../src/general');
 
 describe.each([

--- a/tests/reporter.test.js
+++ b/tests/reporter.test.js
@@ -1,0 +1,21 @@
+// @ts-check
+const { getReporterForReporterName } = require('../src/general');
+
+describe.each([
+	[
+		'human',
+		{ showLineNumbers: false },
+		[{ path: 'path/to/file.js', line: 4, text: 'function helloWorld() {' }],
+		['path/to/file.js:function helloWorld() {'],
+	],
+	[
+		'human',
+		{ showLineNumbers: true },
+		[{ path: 'path/to/file.js', line: 4, text: 'function helloWorld() {' }],
+		['path/to/file.js:4:function helloWorld() {'],
+	],
+])("getReporterForReporterName('%s', %s, %s)", (reporterName, config, searchResults, expected) => {
+	test(`returns '${expected}'`, () => {
+		expect(getReporterForReporterName(reporterName)(searchResults, config)).toEqual(expected);
+	});
+});

--- a/tests/reporter.test.js
+++ b/tests/reporter.test.js
@@ -4,17 +4,17 @@ const { getReporterForReporterName } = require('../src/general');
 describe.each([
 	[
 		'human',
-		{ showLineNumbers: false },
+		{ showLineNumbers: false, disableColor: true },
 		[{ path: 'path/to/file.js', line: 4, text: 'function helloWorld() {' }],
 		['path/to/file.js:function helloWorld() {'],
 	],
 	[
 		'human',
-		{ showLineNumbers: true },
+		{ showLineNumbers: true, disableColor: true },
 		[{ path: 'path/to/file.js', line: 4, text: 'function helloWorld() {' }],
 		['path/to/file.js:4:function helloWorld() {'],
 	],
-])("getReporterForReporterName('%s', %s, %s)", (reporterName, config, searchResults, expected) => {
+])("getReporterForReporterName('%s', %s)", (reporterName, config, searchResults, expected) => {
 	test(`returns '${expected}'`, () => {
 		expect(getReporterForReporterName(reporterName)(searchResults, config)).toEqual(expected);
 	});


### PR DESCRIPTION
This adds the `--line-number` option to display the line number, making it match `grep` and `rg` in that way. Note that this is a breaking change since previously the line number was always included by default.