### PR TITLE
Add support for JS properties and typedefs

### DIFF
--- a/src/general.js
+++ b/src/general.js
@@ -35,10 +35,10 @@ const readdir = util.promisify(fs.readdir);
 
 /**
  * @typedef {object} SearchConfig
- * @property {FileType|null} type
- * @property {boolean} verbose
- * @property {boolean} showLineNumbers
- * @property {boolean} disableColor
+ * @property {FileType|null} [type]
+ * @property {boolean} [verbose]
+ * @property {boolean} [showLineNumbers]
+ * @property {boolean} [disableColor]
  * @property {SearchTool} searchTool
  * @property {Glob} path
  */

--- a/src/lang/js.js
+++ b/src/lang/js.js
@@ -13,7 +13,7 @@ const declarationKeywords = [
 function getRegexp(symbol) {
 	const symbolWithDeclaration = `(${declarationKeywords.map(addTrailingSpace).join('|')})${symbol}\\b`;
 	const prototypeDeclaration = `prototype\\.${symbol}\\b`
-	const methodShorthand = `${symbol}\\([^)]*\\)\\s*\\{`;
+	const methodShorthand = `${symbol}\\([^)]*\\)\\s*(:[^{]+)?\\{`;
 	const methodLonghand = `${symbol}:\\s*function\\([^)]*\\)\\s*\\{`;
 	const methodArrowFunction = `${symbol}:\\s*\\([^)]*\\)\\s*=>\\s*\\{`;
 	const propertyLonghand = `${symbol}:\\s*`;

--- a/src/lang/js.js
+++ b/src/lang/js.js
@@ -15,7 +15,7 @@ function getRegexp(symbol) {
 	const prototypeDeclaration = `\\bprototype\\.${symbol}\\b`
 	const methodShorthand = `\\b${symbol}\\([^)]*\\)\\s*(:[^{]+)?\\{`;
 	const propertyLonghand = `\\b${symbol}:\\s*`;
-	const typedef = `@typedef\\s\\{[^}]+\\}\\s${symbol}\\b`;
+	const typedef = `@typedef\\s(\\{[^}]+\\}\\s)?${symbol}\\b`;
 	const regexpParts = [
 		symbolWithDeclaration,
 		prototypeDeclaration,

--- a/src/lang/js.js
+++ b/src/lang/js.js
@@ -11,17 +11,19 @@ const declarationKeywords = [
 ];
 
 function getRegexp(symbol) {
-	const symbolWithDeclaration = `(${declarationKeywords.map(addTrailingSpace).join('|')})${symbol}\\b`;
-	const prototypeDeclaration = `prototype\\.${symbol}\\b`
-	const methodShorthand = `${symbol}\\([^)]*\\)\\s*(:[^{]+)?\\{`;
-	const propertyLonghand = `${symbol}:\\s*`;
+	const symbolWithDeclaration = `\\b(${declarationKeywords.map(addTrailingSpace).join('|')})${symbol}\\b`;
+	const prototypeDeclaration = `\\bprototype\\.${symbol}\\b`
+	const methodShorthand = `\\b${symbol}\\([^)]*\\)\\s*(:[^{]+)?\\{`;
+	const propertyLonghand = `\\b${symbol}:\\s*`;
+	const typedef = `@typedef\\s\\{[^}]+\\}\\s${symbol}\\b`;
 	const regexpParts = [
 		symbolWithDeclaration,
 		prototypeDeclaration,
 		methodShorthand,
 		propertyLonghand,
+		typedef,
 	];
-	return `\\b(${[regexpParts.join('|')]})`;
+	return `(${[regexpParts.join('|')]})`;
 }
 
 function addTrailingSpace(keyword) {

--- a/src/lang/js.js
+++ b/src/lang/js.js
@@ -1,7 +1,29 @@
 // @format
 
+const declarationKeywords = [
+	'let',
+	'var',
+	'const',
+	'function',
+	'class',
+	'interface',
+	'type',
+];
+
 function getRegexp(symbol) {
-	return `\\b((let\\s|var\\s|const\\s|function\\s|class\\s|interface\\s|type\\s|prototype\\.)${symbol}\\b|${symbol}\\([^)]*\\)\\s*\\{)`;
+	const symbolWithDeclaration = `(${declarationKeywords.map(addTrailingSpace).join('|')})${symbol}\\b`;
+	const prototypeDeclaration = `prototype\\.${symbol}\\b`
+	const methodShorthand = `${symbol}\\([^)]*\\)\\s*\\{`;
+	const regexpParts = [
+		symbolWithDeclaration,
+		prototypeDeclaration,
+		methodShorthand,
+	];
+	return `\\b(${[regexpParts.join('|')]})`;
+}
+
+function addTrailingSpace(keyword) {
+	return keyword + '\\s';
 }
 
 module.exports = getRegexp;

--- a/src/lang/js.js
+++ b/src/lang/js.js
@@ -14,10 +14,14 @@ function getRegexp(symbol) {
 	const symbolWithDeclaration = `(${declarationKeywords.map(addTrailingSpace).join('|')})${symbol}\\b`;
 	const prototypeDeclaration = `prototype\\.${symbol}\\b`
 	const methodShorthand = `${symbol}\\([^)]*\\)\\s*\\{`;
+	const methodLonghand = `${symbol}:\\s*function\\([^)]*\\)\\s*\\{`;
+	const methodArrowFunction = `${symbol}:\\s*\\([^)]*\\)\\s*=>\\s*\\{`;
 	const regexpParts = [
 		symbolWithDeclaration,
 		prototypeDeclaration,
 		methodShorthand,
+		methodLonghand,
+		methodArrowFunction,
 	];
 	return `\\b(${[regexpParts.join('|')]})`;
 }

--- a/src/lang/js.js
+++ b/src/lang/js.js
@@ -14,15 +14,11 @@ function getRegexp(symbol) {
 	const symbolWithDeclaration = `(${declarationKeywords.map(addTrailingSpace).join('|')})${symbol}\\b`;
 	const prototypeDeclaration = `prototype\\.${symbol}\\b`
 	const methodShorthand = `${symbol}\\([^)]*\\)\\s*(:[^{]+)?\\{`;
-	const methodLonghand = `${symbol}:\\s*function\\([^)]*\\)\\s*\\{`;
-	const methodArrowFunction = `${symbol}:\\s*\\([^)]*\\)\\s*=>\\s*\\{`;
 	const propertyLonghand = `${symbol}:\\s*`;
 	const regexpParts = [
 		symbolWithDeclaration,
 		prototypeDeclaration,
 		methodShorthand,
-		methodLonghand,
-		methodArrowFunction,
 		propertyLonghand,
 	];
 	return `\\b(${[regexpParts.join('|')]})`;

--- a/src/lang/js.js
+++ b/src/lang/js.js
@@ -16,12 +16,14 @@ function getRegexp(symbol) {
 	const methodShorthand = `${symbol}\\([^)]*\\)\\s*\\{`;
 	const methodLonghand = `${symbol}:\\s*function\\([^)]*\\)\\s*\\{`;
 	const methodArrowFunction = `${symbol}:\\s*\\([^)]*\\)\\s*=>\\s*\\{`;
+	const propertyLonghand = `${symbol}:\\s*`;
 	const regexpParts = [
 		symbolWithDeclaration,
 		prototypeDeclaration,
 		methodShorthand,
 		methodLonghand,
 		methodArrowFunction,
+		propertyLonghand,
 	];
 	return `\\b(${[regexpParts.join('|')]})`;
 }

--- a/tests/fixtures/js-parent/src/db.js
+++ b/tests/fixtures/js-parent/src/db.js
@@ -31,3 +31,10 @@ const objectWithPropertyLonghand = {
 const objectWithPropertyShorthand = {
 	shorthandProperty,
 };
+
+const arrayDef = [
+	longhandFunction,
+	longhandArrowFunction,
+	longhandProperty,
+	shorthandProperty,
+];

--- a/tests/fixtures/js-parent/src/db.js
+++ b/tests/fixtures/js-parent/src/db.js
@@ -23,3 +23,11 @@ const objectWithArrowFunctionLonghand = {
 		return 'hi';
 	}
 };
+
+const objectWithPropertyLonghand = {
+	longhandProperty: 'hello',
+};
+
+const objectWithPropertyShorthand = {
+	shorthandProperty,
+};

--- a/tests/fixtures/js-parent/src/db.js
+++ b/tests/fixtures/js-parent/src/db.js
@@ -1,13 +1,22 @@
 export function queryDb() {}
+export function queryDbFake() {}
 
 const makeQuery = () => {};
+const makeQueryFake = () => {};
 
 function parseQuery() {
 	const buildParser = () => {};
+	const buildParserFake = () => {};
+}
+
+function parseQueryFake() {
 }
 
 const objectWithFunctionShorthand = {
 	shorthandFunction() {
+		return 'hi';
+	},
+	shorthandFunctionFake() {
 		return 'hi';
 	}
 };
@@ -15,21 +24,29 @@ const objectWithFunctionShorthand = {
 const objectWithFunctionLonghand = {
 	longhandFunction: function() {
 		return 'hi';
+	},
+	longhandFunctionFake: function() {
+		return 'hi';
 	}
 };
 
 const objectWithArrowFunctionLonghand = {
 	longhandArrowFunction: () => {
 		return 'hi';
+	},
+	longhandArrowFunctionFake: () => {
+		return 'hi';
 	}
 };
 
 const objectWithPropertyLonghand = {
 	longhandProperty: 'hello',
+	longhandPropertyFake: 'hello',
 };
 
 const objectWithPropertyShorthand = {
 	shorthandProperty,
+	shorthandPropertyFake,
 };
 
 const arrayDef = [

--- a/tests/fixtures/js-parent/src/db.js
+++ b/tests/fixtures/js-parent/src/db.js
@@ -11,3 +11,15 @@ const objectWithFunctionShorthand = {
 		return 'hi';
 	}
 };
+
+const objectWithFunctionLonghand = {
+	longhandFunction: function() {
+		return 'hi';
+	}
+};
+
+const objectWithArrowFunctionLonghand = {
+	longhandArrowFunction: () => {
+		return 'hi';
+	}
+};

--- a/tests/fixtures/js/db.js
+++ b/tests/fixtures/js/db.js
@@ -11,3 +11,15 @@ const objectWithFunctionShorthand = {
 		return 'hi';
 	}
 };
+
+const objectWithFunctionLonghand = {
+	longhandFunction: function() {
+		return 'hi';
+	}
+};
+
+const objectWithArrowFunctionLonghand = {
+	longhandArrowFunction: () => {
+		return 'hi';
+	}
+};

--- a/tests/fixtures/js/db.js
+++ b/tests/fixtures/js/db.js
@@ -1,13 +1,22 @@
 export function queryDb() {}
+export function queryDbFake() {}
 
 const makeQuery = () => {};
+const makeQueryFake = () => {};
 
 function parseQuery() {
 	const buildParser = () => {};
+	const buildParserFake = () => {};
+}
+
+function parseQueryFake() {
 }
 
 const objectWithFunctionShorthand = {
 	shorthandFunction() {
+		return 'hi';
+	},
+	shorthandFunctionFake() {
 		return 'hi';
 	}
 };
@@ -15,11 +24,34 @@ const objectWithFunctionShorthand = {
 const objectWithFunctionLonghand = {
 	longhandFunction: function() {
 		return 'hi';
+	},
+	longhandFunctionFake: function() {
+		return 'hi';
 	}
 };
 
 const objectWithArrowFunctionLonghand = {
 	longhandArrowFunction: () => {
 		return 'hi';
+	},
+	longhandArrowFunctionFake: () => {
+		return 'hi';
 	}
 };
+
+const objectWithPropertyLonghand = {
+	longhandProperty: 'hello',
+	longhandPropertyFake: 'hello',
+};
+
+const objectWithPropertyShorthand = {
+	shorthandProperty,
+	shorthandPropertyFake,
+};
+
+const arrayDef = [
+	longhandFunction,
+	longhandArrowFunction,
+	longhandProperty,
+	shorthandProperty,
+];

--- a/tests/fixtures/js/misc.ts
+++ b/tests/fixtures/js/misc.ts
@@ -67,3 +67,9 @@ type AType = 'something' | 'somethingelse';
  * @property {number} loaded Number of bytes already transferred
  * @property {number} total  Total number of bytes to transfer
  */
+
+/**
+ * @typedef TypeDefSimple
+ * @property {number} loaded Number of bytes already transferred
+ * @property {number} total  Total number of bytes to transfer
+ */

--- a/tests/fixtures/js/misc.ts
+++ b/tests/fixtures/js/misc.ts
@@ -1,0 +1,69 @@
+export function queryDbTS(): string {}
+export function queryDbTSFake(): string {}
+
+const makeQueryTS: MyFunc = (): string => {};
+const makeQueryTSFake: MyFunc = (): string => {};
+
+function parseQueryTS(): string {
+	const buildParserTS: MyFunc = (): string => {};
+	const buildParserTSFake: MyFunc = (): string => {};
+}
+
+function parseQueryTSFake: MyFunc(): string {
+}
+
+const objectWithFunctionShorthandTS = {
+	shorthandFunctionTS(): string {
+		return 'hi';
+	},
+	shorthandFunctionTSFake(): string {
+		return 'hi';
+	}
+};
+
+const objectWithFunctionLonghandTS = {
+	longhandFunctionTS: function(): string {
+		return 'hi';
+	},
+	longhandFunctionTSFake: function(): string {
+		return 'hi';
+	}
+};
+
+const objectWithArrowFunctionLonghandTS = {
+	longhandArrowFunctionTS: (): string => {
+		return 'hi';
+	},
+	longhandArrowFunctionTSFake: (): string => {
+		return 'hi';
+	}
+};
+
+const objectWithPropertyLonghandTS = {
+	longhandPropertyTS: 'hello',
+	longhandPropertyTSFake: 'hello',
+};
+
+const objectWithPropertyShorthandTS = {
+	shorthandPropertyTS,
+	shorthandPropertyTSFake,
+};
+
+const arrayDef = [
+	longhandFunctionTS,
+	longhandArrowFunctionTS,
+	longhandPropertyTS,
+	shorthandPropertyTS,
+];
+
+interface AnInterface {
+	foo: string;
+}
+
+type AType = 'something' | 'somethingelse';
+
+/**
+ * @typedef {object} TypeDefObject
+ * @property {number} loaded Number of bytes already transferred
+ * @property {number} total  Total number of bytes to transfer
+ */

--- a/tests/search.test.js
+++ b/tests/search.test.js
@@ -3,19 +3,19 @@ const { search } = require('../src/general');
 
 describe.each([
 	['queryDb', 'js', 'js', 1],
-	['makeQuery', 'js', 'js', 3],
-	['parseQuery', 'js', 'js', 5],
-	['parseQuery', 'js', 'js_2_files', 5],
-	['parseQuery', 'js', 'js_directory', 5],
-	['objectWithFunctionShorthand', 'js', 'js', 9],
-	['shorthandFunction', 'js', 'js', 10],
-	['shorthandFunction', undefined, 'js', 10], // auto-detect type
-	['shorthandFunction', undefined, 'js_2_files', 10], // auto_detect type
-	['shorthandFunction', undefined, 'js_directory', 10], // auto_detect type
-	['shorthandFunction', undefined, 'js_parent_directory', 10], // auto_detect type
-	['longhandFunction', undefined, 'js_parent_directory', 16], // auto_detect type
-	['longhandArrowFunction', undefined, 'js_parent_directory', 22], // auto_detect type
-	['longhandProperty', undefined, 'js_parent_directory', 28], // auto_detect type
+	['makeQuery', 'js', 'js', 4],
+	['parseQuery', 'js', 'js', 7],
+	['parseQuery', 'js', 'js_2_files', 7],
+	['parseQuery', 'js', 'js_directory', 7],
+	['objectWithFunctionShorthand', 'js', 'js', 15],
+	['shorthandFunction', 'js', 'js', 16],
+	['shorthandFunction', undefined, 'js', 16], // auto-detect type
+	['shorthandFunction', undefined, 'js_2_files', 16], // auto_detect type
+	['shorthandFunction', undefined, 'js_directory', 16], // auto_detect type
+	['shorthandFunction', undefined, 'js_parent_directory', 16], // auto_detect type
+	['longhandFunction', undefined, 'js_parent_directory', 25], // auto_detect type
+	['longhandArrowFunction', undefined, 'js_parent_directory', 34], // auto_detect type
+	['longhandProperty', undefined, 'js_parent_directory', 43], // auto_detect type
 	['queryDb', 'php', 'php', 2],
 	['$makeQuery', 'php', 'php', 4],
 	['parseQuery', 'php', 'php', 6],

--- a/tests/search.test.js
+++ b/tests/search.test.js
@@ -20,14 +20,25 @@ describe.each([
 	['Bar', 'php', 'php', 14],
 	['Zoom', 'php', 'php', 17],
 	['Zoom', undefined, 'php', 17], // auto-detect type
-])("search('%s', {type: '%s', path: '%s'})", (symbol, type, fixtureType, expectedLine) => {
+])("search('%s', {type: '%s', path: '%s'})",
+
+	/**
+	 * @param {string} symbol
+	 * @param {import('../src/general').FileType} type
+	 * @param {string} fixtureType
+	 * @param {number} expectedLine
+	 */
+	(symbol, type, fixtureType, expectedLine) => {
 	test(`finds line '${expectedLine}'`, async () => {
 		const path = getFixtureForType(fixtureType);
+
+		/** @type {import('../src/general').SearchConfig} */
 		const config = {
 			type,
 			searchTool: 'ripgrep',
 			path,
 		};
+
 		const results = await search(symbol, config);
 		expect(results.length).toEqual(1);
 		const result = results[0];

--- a/tests/search.test.js
+++ b/tests/search.test.js
@@ -16,7 +16,6 @@ describe.each([
 	['longhandFunction', undefined, 'js_parent_directory', 16], // auto_detect type
 	['longhandArrowFunction', undefined, 'js_parent_directory', 22], // auto_detect type
 	['longhandProperty', undefined, 'js_parent_directory', 28], // auto_detect type
-	['shorthandProperty', undefined, 'js_parent_directory', 32], // auto_detect type
 	['queryDb', 'php', 'php', 2],
 	['$makeQuery', 'php', 'php', 4],
 	['parseQuery', 'php', 'php', 6],

--- a/tests/search.test.js
+++ b/tests/search.test.js
@@ -27,6 +27,7 @@ describe.each([
 	['longhandPropertyTS', undefined, 'ts', 43], // auto_detect type
 	['AnInterface', undefined, 'ts', 59], // auto_detect type
 	['AType', undefined, 'ts', 63], // auto_detect type
+	['TypeDefObject', undefined, 'ts', 66], // auto_detect type
 	['queryDb', 'php', 'php', 2],
 	['$makeQuery', 'php', 'php', 4],
 	['parseQuery', 'php', 'php', 6],

--- a/tests/search.test.js
+++ b/tests/search.test.js
@@ -13,6 +13,8 @@ describe.each([
 	['shorthandFunction', undefined, 'js_2_files', 10], // auto_detect type
 	['shorthandFunction', undefined, 'js_directory', 10], // auto_detect type
 	['shorthandFunction', undefined, 'js_parent_directory', 10], // auto_detect type
+	['longhandFunction', undefined, 'js_parent_directory', 16], // auto_detect type
+	['longhandArrowFunction', undefined, 'js_parent_directory', 22], // auto_detect type
 	['queryDb', 'php', 'php', 2],
 	['$makeQuery', 'php', 'php', 4],
 	['parseQuery', 'php', 'php', 6],

--- a/tests/search.test.js
+++ b/tests/search.test.js
@@ -15,6 +15,8 @@ describe.each([
 	['shorthandFunction', undefined, 'js_parent_directory', 10], // auto_detect type
 	['longhandFunction', undefined, 'js_parent_directory', 16], // auto_detect type
 	['longhandArrowFunction', undefined, 'js_parent_directory', 22], // auto_detect type
+	['longhandProperty', undefined, 'js_parent_directory', 28], // auto_detect type
+	['shorthandProperty', undefined, 'js_parent_directory', 32], // auto_detect type
 	['queryDb', 'php', 'php', 2],
 	['$makeQuery', 'php', 'php', 4],
 	['parseQuery', 'php', 'php', 6],

--- a/tests/search.test.js
+++ b/tests/search.test.js
@@ -3,19 +3,30 @@ const { search } = require('../src/general');
 
 describe.each([
 	['queryDb', 'js', 'js', 1],
+	['queryDbTS', 'js', 'ts', 1],
 	['makeQuery', 'js', 'js', 4],
+	['makeQueryTS', 'js', 'ts', 4],
 	['parseQuery', 'js', 'js', 7],
 	['parseQuery', 'js', 'js_2_files', 7],
 	['parseQuery', 'js', 'js_directory', 7],
+	['parseQueryTS', 'js', 'ts', 7],
 	['objectWithFunctionShorthand', 'js', 'js', 15],
+	['objectWithFunctionShorthandTS', 'js', 'ts', 15],
 	['shorthandFunction', 'js', 'js', 16],
+	['shorthandFunctionTS', 'js', 'ts', 16],
 	['shorthandFunction', undefined, 'js', 16], // auto-detect type
+	['shorthandFunctionTS', undefined, 'ts', 16], // auto-detect type
 	['shorthandFunction', undefined, 'js_2_files', 16], // auto_detect type
 	['shorthandFunction', undefined, 'js_directory', 16], // auto_detect type
 	['shorthandFunction', undefined, 'js_parent_directory', 16], // auto_detect type
 	['longhandFunction', undefined, 'js_parent_directory', 25], // auto_detect type
+	['longhandFunctionTS', undefined, 'ts', 25], // auto_detect type
 	['longhandArrowFunction', undefined, 'js_parent_directory', 34], // auto_detect type
+	['longhandArrowFunctionTS', undefined, 'ts', 34], // auto_detect type
 	['longhandProperty', undefined, 'js_parent_directory', 43], // auto_detect type
+	['longhandPropertyTS', undefined, 'ts', 43], // auto_detect type
+	['AnInterface', undefined, 'ts', 59], // auto_detect type
+	['AType', undefined, 'ts', 63], // auto_detect type
 	['queryDb', 'php', 'php', 2],
 	['$makeQuery', 'php', 'php', 4],
 	['parseQuery', 'php', 'php', 6],
@@ -57,6 +68,8 @@ describe.each([
  */
 function getFixtureForType(type) {
 	switch (type) {
+		case 'ts':
+			return './tests/fixtures/js/misc.ts';
 		case 'js':
 			return './tests/fixtures/js/db.js';
 		case 'js_2_files':
@@ -78,6 +91,8 @@ function getFixtureForType(type) {
  */
 function getExpectedResultPath(type) {
 	switch (type) {
+		case 'ts':
+			return './tests/fixtures/js/misc.ts';
 		case 'js':
 		case 'js_2_files':
 		case 'js_directory':

--- a/tests/search.test.js
+++ b/tests/search.test.js
@@ -28,6 +28,7 @@ describe.each([
 	['AnInterface', undefined, 'ts', 59], // auto_detect type
 	['AType', undefined, 'ts', 63], // auto_detect type
 	['TypeDefObject', undefined, 'ts', 66], // auto_detect type
+	['TypeDefSimple', undefined, 'ts', 72], // auto_detect type
 	['queryDb', 'php', 'php', 2],
 	['$makeQuery', 'php', 'php', 4],
 	['parseQuery', 'php', 'php', 6],


### PR DESCRIPTION
This adds support for finding JS symbols like the following instances:

```js
{
  longhandMethod: function() {},
  arrowMethod: () => {},
  propertyLonghand: 'here',
  propertyShorthand,
}
```

This also adds support for JSDoc `@typedef` definitions.