### PR TITLE
Return results as soon as we have them

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -496,7 +496,13 @@ impl Searcher {
         self.debug("Listening to searcher results");
         for received_results in rx {
             for received_result in received_results {
-                callback(received_result)
+                callback(received_result);
+                // Don't try to even calculate elapsed time if we are not going to print it
+                if let (true, Some(start)) = (self.config.debug, start) {
+                    self.debug(
+                        format!("Found a result in {} ms", start.elapsed().as_millis()).as_str(),
+                    );
+                }
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -417,25 +417,20 @@ impl Searcher {
     }
 
     /// Perform the search and run a callback for each formatted string
-    pub fn search_and_format_callback<F, E>(&self, mut callback: F, error: E)
+    pub fn search_and_format_callback<F>(&self, mut callback: F) -> Result<(), Box<dyn Error>>
     where
         F: FnMut(String),
-        E: FnMut(Box<dyn Error>),
     {
-        self.search_callback(
-            |result| match self.config.format {
-                SearchResultFormat::Grep => callback(result.to_grep()),
-                SearchResultFormat::JsonPerMatch => callback(result.to_json_per_match()),
-            },
-            error,
-        );
+        self.search_callback(|result| match self.config.format {
+            SearchResultFormat::Grep => callback(result.to_grep()),
+            SearchResultFormat::JsonPerMatch => callback(result.to_json_per_match()),
+        })
     }
 
     /// Perform the search and call the callback for each result
-    pub fn search_callback<F, E>(&self, mut callback: F, mut error: E)
+    pub fn search_callback<F>(&self, mut callback: F) -> Result<(), Box<dyn Error>>
     where
         F: FnMut(SearchResult),
-        E: FnMut(Box<dyn Error>),
     {
         // Don't try to even calculate elapsed time if we are not going to print it
         let start: Option<time::Instant> = if self.config.debug {
@@ -463,8 +458,7 @@ impl Searcher {
                     let path = match entry {
                         Ok(path) => path.into_path(),
                         Err(err) => {
-                            error(Box::new(err));
-                            continue;
+                            return Err(Box::new(err));
                         }
                     };
                     if path.is_dir() {
@@ -473,8 +467,7 @@ impl Searcher {
                     let path = match path.to_str() {
                         Some(p) => p.to_string(),
                         None => {
-                            error(Box::from("Error getting string from path"));
-                            continue;
+                            return Err(Box::from("Error getting string from path"));
                         }
                     };
                     if !file_type_re.is_match(&path) {
@@ -530,6 +523,7 @@ impl Searcher {
                 .as_str(),
             );
         }
+        Ok(())
     }
 
     /// Perform the search and return [SearchResult] structs

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -411,7 +411,7 @@ impl Searcher {
     pub fn search_and_format_callback<F, E>(&self, mut callback: F, error: E)
     where
         F: FnMut(String),
-        E: Fn(Box<dyn Error>),
+        E: FnMut(Box<dyn Error>),
     {
         self.search_callback(
             |result| match self.config.format {
@@ -423,10 +423,10 @@ impl Searcher {
     }
 
     /// Perform the search and call the callback for each result
-    pub fn search_callback<F, E>(&self, mut callback: F, error: E)
+    pub fn search_callback<F, E>(&self, mut callback: F, mut error: E)
     where
         F: FnMut(SearchResult),
-        E: Fn(Box<dyn Error>),
+        E: FnMut(Box<dyn Error>),
     {
         // Don't try to even calculate elapsed time if we are not going to print it
         let start: Option<time::Instant> = if self.config.debug {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,8 +58,6 @@ use std::fs;
 use std::io::{self, BufRead, Seek};
 use std::num::NonZero;
 use std::sync::mpsc;
-use std::sync::Arc;
-use std::sync::Mutex;
 use std::time;
 use strum_macros::Display;
 use strum_macros::EnumString;
@@ -520,81 +518,12 @@ impl Searcher {
 
     /// Perform the search and return [SearchResult] structs
     pub fn search(&self) -> Result<Vec<SearchResult>, Box<dyn Error>> {
-        // Don't try to even calculate elapsed time if we are not going to print it
-        let start: Option<time::Instant> = if self.config.debug {
-            Some(time::Instant::now())
-        } else {
-            None
-        };
-        let re = query_regex::get_regex_for_query(&self.config.query, &self.config.file_type);
-        let file_type_re = file_type::get_regexp_for_file_type(&self.config.file_type);
-        let mut pool = threads::ThreadPool::new(self.config.num_threads);
-        let results: Vec<SearchResult> = vec![];
-        let results = Arc::new(Mutex::new(results));
-
-        if self.config.no_color {
-            colored::control::set_override(false);
+        let mut results: Vec<SearchResult> = vec![];
+        let search_result = self.search_callback(|result| results.push(result));
+        match search_result {
+            Ok(_) => Ok(results),
+            Err(err) => Err(err),
         }
-
-        self.debug("Starting searchers");
-        let mut searched_file_count = 0;
-        for file_path in &self.config.file_paths {
-            for entry in Walk::new(file_path) {
-                let path = entry?.into_path();
-                if path.is_dir() {
-                    continue;
-                }
-                let path = match path.to_str() {
-                    Some(p) => p.to_string(),
-                    None => return Err("Error getting string from path".into()),
-                };
-                if !file_type_re.is_match(&path) {
-                    continue;
-                }
-                searched_file_count += 1;
-
-                let re1 = re.clone();
-                let path1 = path.clone();
-                let config1 = self.config.clone();
-                let results1 = Arc::clone(&results);
-                pool.execute(move || {
-                    search_file(
-                        &re1,
-                        &path1,
-                        &config1,
-                        move |file_results: Vec<SearchResult>| {
-                            results1
-                                .lock()
-                                .expect("Unable to collect search data from thread")
-                                .extend(file_results);
-                        },
-                    );
-                })
-            }
-        }
-
-        self.debug("Waiting for searchers to complete");
-        pool.wait_for_all_jobs_and_stop();
-        self.debug("Searchers complete");
-
-        let results = Arc::into_inner(results)
-            .expect("Unable to collect search results from threads: reference counter failed");
-        let results = results
-            .into_inner()
-            .expect("Unable to collect search results from threads: mutex failed");
-
-        // Don't try to even calculate elapsed time if we are not going to print it
-        if let (true, Some(start)) = (self.config.debug, start) {
-            self.debug(
-                format!(
-                    "Scanned {} files in {} ms",
-                    searched_file_count,
-                    start.elapsed().as_millis()
-                )
-                .as_str(),
-            );
-        }
-        Ok(results)
     }
 
     fn debug(&self, output: &str) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -397,14 +397,23 @@ impl Searcher {
 
     /// Perform the search and return formatted strings
     pub fn search_and_format(&self) -> Result<Vec<String>, Box<dyn Error>> {
-        let results = self.search()?;
-        Ok(results
-            .iter()
-            .map(|result| match self.config.format {
-                SearchResultFormat::Grep => result.to_grep(),
-                SearchResultFormat::JsonPerMatch => result.to_json_per_match(),
-            })
-            .collect())
+        let mut results: Vec<String> = vec![];
+        let mut errors: Vec<Box<dyn Error>> = vec![];
+        let error = |err| {
+            errors.push(err);
+        };
+        self.search_callback(
+            |result| match self.config.format {
+                SearchResultFormat::Grep => results.push(result.to_grep()),
+                SearchResultFormat::JsonPerMatch => results.push(result.to_json_per_match()),
+            },
+            error,
+        );
+        if errors.len() > 0 {
+            // FIXME: let's not use unwrap; there has to be a more idiomatic way
+            return Err(errors.into_iter().nth(0).unwrap());
+        }
+        Ok(results)
     }
 
     /// Perform the search and run a callback for each formatted string

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -408,20 +408,25 @@ impl Searcher {
     }
 
     /// Perform the search and run a callback for each formatted string
-    pub fn search_and_format_callback<F>(&self, callback: F)
+    pub fn search_and_format_callback<F, E>(&self, callback: F, error: E)
     where
         F: Fn(String),
+        E: Fn(Box<dyn Error>),
     {
-        self.search_callback(|result| match self.config.format {
-            SearchResultFormat::Grep => callback(result.to_grep()),
-            SearchResultFormat::JsonPerMatch => callback(result.to_json_per_match()),
-        });
+        self.search_callback(
+            |result| match self.config.format {
+                SearchResultFormat::Grep => callback(result.to_grep()),
+                SearchResultFormat::JsonPerMatch => callback(result.to_json_per_match()),
+            },
+            error,
+        );
     }
 
     /// Perform the search and call the callback for each result
-    pub fn search_callback<F>(&self, callback: F)
+    pub fn search_callback<F, E>(&self, callback: F, error: E)
     where
         F: Fn(SearchResult),
+        E: Fn(Box<dyn Error>),
     {
         // Don't try to even calculate elapsed time if we are not going to print it
         let start: Option<time::Instant> = if self.config.debug {
@@ -446,13 +451,22 @@ impl Searcher {
             let (tx, rx) = mpsc::channel();
             for file_path in &self.config.file_paths {
                 for entry in Walk::new(file_path) {
-                    let path = entry.unwrap().into_path(); // TODO: handle errors
+                    let path = match entry {
+                        Ok(path) => path.into_path(),
+                        Err(err) => {
+                            error(Box::new(err));
+                            continue;
+                        }
+                    };
                     if path.is_dir() {
                         continue;
                     }
                     let path = match path.to_str() {
                         Some(p) => p.to_string(),
-                        None => panic!("Error getting string from path"), // TODO: handle errors
+                        None => {
+                            error(Box::from("Error getting string from path"));
+                            continue;
+                        }
                     };
                     if !file_type_re.is_match(&path) {
                         continue;
@@ -468,9 +482,10 @@ impl Searcher {
                             &re1,
                             &path1,
                             &config1,
-                            move |file_results: Vec<SearchResult>| {
-                                tx1.send(file_results).unwrap(); // TODO: handle errors
-                            },
+                            // NOTE: it would be nice to have better error handling for if this
+                            // message send fails, but since error handling would happen through
+                            // message sending, I don't know what else to do other than panic.
+                            move |file_results: Vec<SearchResult>| tx1.send(file_results).unwrap(),
                         );
                     })
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -378,9 +378,12 @@ impl SearchResult {
 ///     true
 /// ))
 /// .unwrap();
+///
 /// for result in searcher.search_and_format().unwrap() {
 ///     println!("{}", result);
 /// }
+///
+/// searcher.search_and_format_callback(|line| println!("{}", line));
 /// ```
 pub struct Searcher {
     config: Config,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -408,9 +408,9 @@ impl Searcher {
     }
 
     /// Perform the search and run a callback for each formatted string
-    pub fn search_and_format_callback<F, E>(&self, callback: F, error: E)
+    pub fn search_and_format_callback<F, E>(&self, mut callback: F, error: E)
     where
-        F: Fn(String),
+        F: FnMut(String),
         E: Fn(Box<dyn Error>),
     {
         self.search_callback(
@@ -423,9 +423,9 @@ impl Searcher {
     }
 
     /// Perform the search and call the callback for each result
-    pub fn search_callback<F, E>(&self, callback: F, error: E)
+    pub fn search_callback<F, E>(&self, mut callback: F, error: E)
     where
-        F: Fn(SearchResult),
+        F: FnMut(SearchResult),
         E: Fn(Box<dyn Error>),
     {
         // Don't try to even calculate elapsed time if we are not going to print it

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,7 @@ use std::error::Error;
 use std::fs;
 use std::io::{self, BufRead, Seek};
 use std::num::NonZero;
+use std::sync::mpsc;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::time;
@@ -404,6 +405,101 @@ impl Searcher {
                 SearchResultFormat::JsonPerMatch => result.to_json_per_match(),
             })
             .collect())
+    }
+
+    /// Perform the search and run a callback for each formatted string
+    pub fn search_and_format_callback<F>(&self, callback: F)
+    where
+        F: Fn(String),
+    {
+        self.search_callback(|result| match self.config.format {
+            SearchResultFormat::Grep => callback(result.to_grep()),
+            SearchResultFormat::JsonPerMatch => callback(result.to_json_per_match()),
+        });
+    }
+
+    /// Perform the search and call the callback for each result
+    pub fn search_callback<F>(&self, callback: F)
+    where
+        F: Fn(SearchResult),
+    {
+        // Don't try to even calculate elapsed time if we are not going to print it
+        let start: Option<time::Instant> = if self.config.debug {
+            Some(time::Instant::now())
+        } else {
+            None
+        };
+        let re = query_regex::get_regex_for_query(&self.config.query, &self.config.file_type);
+        let file_type_re = file_type::get_regexp_for_file_type(&self.config.file_type);
+        let mut pool = threads::ThreadPool::new(self.config.num_threads);
+
+        if self.config.no_color {
+            colored::control::set_override(false);
+        }
+
+        self.debug("Starting searchers");
+        let mut searched_file_count = 0;
+
+        // Create a scope for tx to live in because it is cloned by all files and we need all
+        // senders to go out of scope for the iterator to end.
+        let rx = {
+            let (tx, rx) = mpsc::channel();
+            for file_path in &self.config.file_paths {
+                for entry in Walk::new(file_path) {
+                    let path = entry.unwrap().into_path(); // TODO: handle errors
+                    if path.is_dir() {
+                        continue;
+                    }
+                    let path = match path.to_str() {
+                        Some(p) => p.to_string(),
+                        None => panic!("Error getting string from path"), // TODO: handle errors
+                    };
+                    if !file_type_re.is_match(&path) {
+                        continue;
+                    }
+                    searched_file_count += 1;
+
+                    let re1 = re.clone();
+                    let path1 = path.clone();
+                    let config1 = self.config.clone();
+                    let tx1 = tx.clone();
+                    pool.execute(move || {
+                        search_file(
+                            &re1,
+                            &path1,
+                            &config1,
+                            move |file_results: Vec<SearchResult>| {
+                                tx1.send(file_results).unwrap(); // TODO: handle errors
+                            },
+                        );
+                    })
+                }
+            }
+            rx
+        };
+
+        self.debug("Listening to searcher results");
+        for received_results in rx {
+            for received_result in received_results {
+                callback(received_result)
+            }
+        }
+
+        self.debug("Waiting for searchers to complete");
+        pool.wait_for_all_jobs_and_stop();
+        self.debug("Searchers complete");
+
+        // Don't try to even calculate elapsed time if we are not going to print it
+        if let (true, Some(start)) = (self.config.debug, start) {
+            self.debug(
+                format!(
+                    "Scanned {} files in {} ms",
+                    searched_file_count,
+                    start.elapsed().as_millis()
+                )
+                .as_str(),
+            );
+        }
     }
 
     /// Perform the search and return [SearchResult] structs

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -398,22 +398,14 @@ impl Searcher {
     /// Perform the search and return formatted strings
     pub fn search_and_format(&self) -> Result<Vec<String>, Box<dyn Error>> {
         let mut results: Vec<String> = vec![];
-        let mut errors: Vec<Box<dyn Error>> = vec![];
-        let error = |err| {
-            errors.push(err);
-        };
-        self.search_callback(
-            |result| match self.config.format {
-                SearchResultFormat::Grep => results.push(result.to_grep()),
-                SearchResultFormat::JsonPerMatch => results.push(result.to_json_per_match()),
-            },
-            error,
-        );
-        if errors.len() > 0 {
-            // FIXME: let's not use unwrap; there has to be a more idiomatic way
-            return Err(errors.into_iter().nth(0).unwrap());
+        let search_result = self.search_callback(|result| match self.config.format {
+            SearchResultFormat::Grep => results.push(result.to_grep()),
+            SearchResultFormat::JsonPerMatch => results.push(result.to_json_per_match()),
+        });
+        match search_result {
+            Ok(_) => Ok(results),
+            Err(err) => Err(err),
         }
-        Ok(results)
     }
 
     /// Perform the search and run a callback for each formatted string

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,15 +8,7 @@ fn main() {
         eprintln!("{err}");
         process::exit(exitcode::USAGE);
     });
-    match searcher.search_and_format() {
-        Ok(results) => {
-            for line in results {
-                println!("{}", line);
-            }
-        }
-        Err(err) => {
-            eprintln!("{err}");
-            process::exit(exitcode::USAGE);
-        }
-    };
+    searcher.search_and_format_callback(|line| {
+        println!("{}", line);
+    });
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,13 +8,14 @@ fn main() {
         eprintln!("{err}");
         process::exit(exitcode::USAGE);
     });
-    searcher.search_and_format_callback(
-        |line| {
-            println!("{}", line);
-        },
-        |err| {
+    let search_result = searcher.search_and_format_callback(|line| {
+        println!("{}", line);
+    });
+    match search_result {
+        Ok(_) => {}
+        Err(err) => {
             eprintln!("{err}");
             process::exit(exitcode::USAGE);
-        },
-    );
+        }
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,13 @@ fn main() {
         eprintln!("{err}");
         process::exit(exitcode::USAGE);
     });
-    searcher.search_and_format_callback(|line| {
-        println!("{}", line);
-    });
+    searcher.search_and_format_callback(
+        |line| {
+            println!("{}", line);
+        },
+        |err| {
+            eprintln!("{err}");
+            process::exit(exitcode::USAGE);
+        },
+    );
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -26,11 +26,27 @@ pub fn do_search(args: Args) -> Vec<SearchResult> {
     searcher.search().expect("Search failed for test")
 }
 
+pub fn do_search_callback(args: Args) -> Vec<SearchResult> {
+    let searcher = Searcher::new(args).unwrap();
+    let mut results = vec![];
+    searcher.search_callback(|l| results.push(l)).expect("Search failed for test");
+    results
+}
+
 pub fn do_search_format(args: Args) -> Vec<String> {
     let searcher = Searcher::new(args).unwrap();
     searcher
         .search_and_format()
         .expect("Search failed for test")
+}
+
+pub fn do_search_format_callback(args: Args) -> Vec<String> {
+    let searcher = Searcher::new(args).unwrap();
+    let mut results = vec![];
+    searcher
+        .search_and_format_callback(|l| results.push(l))
+        .expect("Search failed for test");
+    results
 }
 
 pub fn get_default_fixture_for_file_type_string(file_type_string: &str) -> Result<String, String> {

--- a/tests/fixtures/by-language/php-fixture.php
+++ b/tests/fixtures/by-language/php-fixture.php
@@ -43,3 +43,10 @@ class ClassWithConstant {
 		echo GLOBALDEFINE;
 	}
 }
+
+class ClassWithNonUniqueMethod1 {
+	public function similarMethod() {}
+}
+class ClassWithNonUniqueMethod2 {
+	public function similarMethod() {}
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -327,6 +327,27 @@ fn search_returns_expected_line_number_for_file_type(
 }
 
 #[rstest]
+#[case::php_non_unique_method(String::from("similarMethod"), String::from("php"), [48, 51])]
+fn search_returns_expected_line_number_group_for_file_type(
+    #[case] query: String,
+    #[case] file_type_string: String,
+    #[case] line_numbers: [usize;2],
+) {
+    let file_path =
+        common::get_default_fixture_for_file_type_string(file_type_string.as_str()).unwrap();
+    let args = common::make_args(query, Some(file_path), Some(file_type_string));
+    let actual = common::do_search(args);
+    assert_eq!(line_numbers.len(), actual.len(), "Did not find expected number of matches");
+    for (i, result) in actual.iter().enumerate() {
+        assert_eq!(
+            line_numbers[i],
+            result.line_number.unwrap(),
+            "Match found but it has the wrong line number"
+        );
+    }
+}
+
+#[rstest]
 fn search_returns_matching_js_function_line_for_recursive() {
     let file_path = String::from("./tests");
     let query = String::from("parseQuery");

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -56,6 +56,22 @@ fn to_grep_formats_message_without_number() {
 }
 
 #[rstest]
+fn to_grep_from_callback_formats_message_without_number() {
+    let file_path = common::get_default_fixture_for_file_type_string("js").unwrap();
+    let query = String::from("parseQuery");
+    let expected_result = common::get_expected_search_result_for_file_type("js");
+    let expected = format!("{}:{}", expected_result.file_path, expected_result.text);
+    let file_type_string = String::from("js");
+    let mut args = common::make_args(query, Some(file_path), Some(file_type_string));
+    args.line_number = false;
+    args.no_color = true;
+    let actual = common::do_search_callback(args);
+    for result in actual {
+        assert_eq!(expected, result.to_grep());
+    }
+}
+
+#[rstest]
 fn to_grep_formats_message_with_number() {
     let file_path = common::get_default_fixture_for_file_type_string("js").unwrap();
     let query = String::from("parseQuery");
@@ -71,6 +87,27 @@ fn to_grep_formats_message_with_number() {
     args.line_number = true;
     args.no_color = true;
     let actual = common::do_search(args);
+    for result in actual {
+        assert_eq!(expected, result.to_grep());
+    }
+}
+
+#[rstest]
+fn to_grep_from_callback_formats_message_with_number() {
+    let file_path = common::get_default_fixture_for_file_type_string("js").unwrap();
+    let query = String::from("parseQuery");
+    let expected_result = common::get_expected_search_result_for_file_type("js");
+    let expected = format!(
+        "{}:{}:{}",
+        expected_result.file_path,
+        expected_result.line_number.unwrap(),
+        expected_result.text
+    );
+    let file_type_string = String::from("js");
+    let mut args = common::make_args(query, Some(file_path), Some(file_type_string));
+    args.line_number = true;
+    args.no_color = true;
+    let actual = common::do_search_callback(args);
     for result in actual {
         assert_eq!(expected, result.to_grep());
     }
@@ -93,6 +130,28 @@ fn search_and_format_returns_formatted_string_for_grep_with_number() {
     args.no_color = true;
     args.format = Some(SearchResultFormat::Grep);
     let actual = common::do_search_format(args);
+    for result in actual {
+        assert_eq!(expected, result);
+    }
+}
+
+#[rstest]
+fn search_and_format_callback_provides_formatted_string_for_grep_with_number() {
+    let file_path = common::get_default_fixture_for_file_type_string("js").unwrap();
+    let query = String::from("parseQuery");
+    let expected_result = common::get_expected_search_result_for_file_type("js");
+    let expected = format!(
+        "{}:{}:{}",
+        expected_result.file_path,
+        expected_result.line_number.unwrap(),
+        expected_result.text
+    );
+    let file_type_string = String::from("js");
+    let mut args = common::make_args(query, Some(file_path), Some(file_type_string));
+    args.line_number = true;
+    args.no_color = true;
+    args.format = Some(SearchResultFormat::Grep);
+    let actual = common::do_search_format_callback(args);
     for result in actual {
         assert_eq!(expected, result);
     }
@@ -152,6 +211,26 @@ fn search_and_format_returns_formatted_string_for_json_per_match_without_number(
     args.no_color = true;
     args.format = Some(SearchResultFormat::JsonPerMatch);
     let actual = common::do_search_format(args);
+    for result in actual {
+        assert_eq!(expected, result);
+    }
+}
+
+#[rstest]
+fn search_and_format_callback_provides_formatted_string_for_json_per_match_with_number() {
+    let file_path = common::get_default_fixture_for_file_type_string("js").unwrap();
+    let query = String::from("parseQuery");
+    let expected_result = common::get_expected_search_result_for_file_type("js");
+    let expected = format!(
+        "{{\"file_path\":\"{}\",\"line_number\":null,\"text\":\"{}\"}}",
+        expected_result.file_path, expected_result.text
+    );
+    let file_type_string = String::from("js");
+    let mut args = common::make_args(query, Some(file_path), Some(file_type_string));
+    args.line_number = false;
+    args.no_color = true;
+    args.format = Some(SearchResultFormat::JsonPerMatch);
+    let actual = common::do_search_format_callback(args);
     for result in actual {
         assert_eq!(expected, result);
     }


### PR DESCRIPTION
Fixes #38 

This PR adds a new API (the functions `search_and_format_callback` and `search_callback`) that return nothing and instead operate via callbacks; the result callback is called for each result and the error callback is called for each error. This should make for a much simpler consumer API in most cases. 

## To do

- [x] ~Make this optional based on config?~ Maybe it doesn't matter. This should just be better.
- [x] Document the new API.
- [x] Add tests for new API.
- [x] Refactor non-callback search to use new API? It seems flexible enough to do that without needing a mutex.
- [x] Should the new API functions return an error (maybe returning `Result<(), Box<dyn Error>>`) instead of having an error callback? I guess it depends if we want to continue to stop when errors occur. It would probably make replacing the old API with the new one more easy.