### PR TITLE
Add JsonList format

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -369,18 +369,41 @@ pub enum SearchResultFormat {
 
 /// The type of a search event
 ///
+/// Search events are a concept that really only exists for [SearchResultFormat::JsonList].
+///
+/// When that flag is not enabled, [SearchResult] will have an `event_type` property that is always
+/// [SearchEventType::NONE] and serialized instances of [SearchResult] will exclude the property
+/// entirely.
+///
+/// When [SearchResultFormat::JsonList] is enabled, the list of results will include a
+/// [SearchEventResult] at the start and end of its list with [SearchEventType::START] and
+/// [SearchEventType::END] respectively. Also, each [SearchResult] match will have the `event_type`
+/// property [SearchEventType::MATCH].
+///
 /// Most search events are of type [SearchEventType::MATCH], but [SearchResultFormat::JsonList]
 /// includes results for the start and end of a search as well.
 #[derive(Debug, PartialEq, Clone, Serialize)]
 pub enum SearchEventType {
-    /// The start of a search
+    /// The start of a search. Only present in [SearchResultFormat::JsonList].
     START,
 
-    /// The end of a search
+    /// The end of a search. Only present in [SearchResultFormat::JsonList].
     END,
 
-    /// A match
+    /// A match. Each result will use this in [SearchResultFormat::JsonList].
     MATCH,
+
+    /// An empty type. Primarily used when [SearchResultFormat::JsonList] is not set.
+    NONE,
+}
+
+impl SearchEventType {
+    fn is_empty(&self) -> bool {
+        match self {
+            SearchEventType::NONE => true,
+            _ => false,
+        }
+    }
 }
 
 /// A search event that is not a result but rather just an informative marker
@@ -397,6 +420,7 @@ impl SearchEventResult {
             SearchEventType::START => serde_json::to_string(self).unwrap_or_default() + ",",
             SearchEventType::END => serde_json::to_string(self).unwrap_or_default(),
             SearchEventType::MATCH => serde_json::to_string(self).unwrap_or_default() + ",",
+            SearchEventType::NONE => String::from(""),
         }
     }
 }
@@ -407,6 +431,7 @@ impl SearchEventResult {
 #[derive(Debug, PartialEq, Clone, Serialize)]
 pub struct SearchResult {
     /// The event type. This will always be [SearchEventType::MATCH].
+    #[serde(skip_serializing_if = "SearchEventType::is_empty")]
     pub event_type: SearchEventType,
 
     /// The path to the file containing the symbol definition
@@ -738,7 +763,10 @@ fn search_file_line_by_line(
             };
 
             Some(SearchResult {
-                event_type: SearchEventType::MATCH,
+                event_type: match config.format {
+                    SearchResultFormat::JsonList => SearchEventType::MATCH,
+                    _ => SearchEventType::NONE,
+                },
                 file_path: String::from(file_path),
                 line_number: if config.line_number {
                     Some(line_counter)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -353,7 +353,7 @@ impl ColorOption {
     }
 }
 
-/// The output format of [SearchResult::to_string]
+/// The output format of [SearchResult]
 #[derive(clap::ValueEnum, Clone, Default, Debug, EnumString, PartialEq, Display, Copy)]
 pub enum SearchResultFormat {
     /// grep-like output; colon-separated path, line number, and text
@@ -362,6 +362,35 @@ pub enum SearchResultFormat {
 
     /// JSON output; one document per match
     JsonPerMatch,
+
+    /// JSON output; one array document with all results
+    JsonList,
+}
+
+#[derive(serde::Serialize)]
+enum SearchEventType {
+    /// The start of a search
+    START,
+
+    /// The end of a search
+    END,
+}
+
+/// A search event that is not a result but rather just an informative marker
+///
+/// This is required because the [SearchResultFormat::JsonList] format needs "start" and "end" markers.
+#[derive(serde::Serialize)]
+struct SearchEventResult {
+    pub event_type: SearchEventType,
+}
+
+impl SearchEventResult {
+    pub fn to_json_in_list(&self) -> String {
+        match self.event_type {
+            SearchEventType::START => serde_json::to_string(self).unwrap_or_default() + ",",
+            SearchEventType::END => serde_json::to_string(self).unwrap_or_default(),
+        }
+    }
 }
 
 /// A result from calling [Searcher::search] or [Searcher::search_and_format]
@@ -404,9 +433,14 @@ impl SearchResult {
         }
     }
 
-    /// Return a formatted string for output in the "JSON_PER_MATCH" format
+    /// Return a formatted string for output in the [SearchResultFormat::JsonPerMatch] format
     pub fn to_json_per_match(&self) -> String {
         serde_json::to_string(self).unwrap_or_default()
+    }
+
+    /// Return a formatted string for output in the [SearchResultFormat::JsonList] format
+    pub fn to_json_in_list(&self) -> String {
+        serde_json::to_string(self).unwrap_or_default() + ","
     }
 }
 
@@ -451,6 +485,7 @@ impl Searcher {
             .map(|result| match self.config.format {
                 SearchResultFormat::Grep => result.to_grep(),
                 SearchResultFormat::JsonPerMatch => result.to_json_per_match(),
+                SearchResultFormat::JsonList => result.to_json_in_list(),
             })
             .collect())
     }
@@ -460,10 +495,26 @@ impl Searcher {
     where
         F: FnMut(String),
     {
-        self.search_callback(|result| match self.config.format {
+        if self.config.format == SearchResultFormat::JsonList {
+            callback(String::from("["));
+            let event = SearchEventResult {
+                event_type: SearchEventType::START,
+            };
+            callback(event.to_json_in_list());
+        }
+        let error = self.search_callback(|result| match self.config.format {
             SearchResultFormat::Grep => callback(result.to_grep()),
             SearchResultFormat::JsonPerMatch => callback(result.to_json_per_match()),
-        })
+            SearchResultFormat::JsonList => callback(result.to_json_in_list()),
+        });
+        if self.config.format == SearchResultFormat::JsonList {
+            let event = SearchEventResult {
+                event_type: SearchEventType::END,
+            };
+            callback(event.to_json_in_list());
+            callback(String::from("]"));
+        }
+        error
     }
 
     /// Perform the search and call the callback for each result

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -479,15 +479,12 @@ impl Searcher {
 
     /// Perform the search and return formatted strings
     pub fn search_and_format(&self) -> Result<Vec<String>, Box<dyn Error>> {
-        let results = self.search()?;
-        Ok(results
-            .iter()
-            .map(|result| match self.config.format {
-                SearchResultFormat::Grep => result.to_grep(),
-                SearchResultFormat::JsonPerMatch => result.to_json_per_match(),
-                SearchResultFormat::JsonList => result.to_json_in_list(),
-            })
-            .collect())
+        let mut results: Vec<String> = vec![];
+        let error = self.search_and_format_callback(|result| results.push(result));
+        match error {
+            Ok(_) => Ok(results),
+            Err(err) => Err(err),
+        }
     }
 
     /// Perform the search and run a callback for each formatted string

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -367,13 +367,20 @@ pub enum SearchResultFormat {
     JsonList,
 }
 
-#[derive(serde::Serialize)]
-enum SearchEventType {
+/// The type of a search event
+///
+/// Most search events are of type [SearchEventType::MATCH], but [SearchResultFormat::JsonList]
+/// includes results for the start and end of a search as well.
+#[derive(Debug, PartialEq, Clone, Serialize)]
+pub enum SearchEventType {
     /// The start of a search
     START,
 
     /// The end of a search
     END,
+
+    /// A match
+    MATCH,
 }
 
 /// A search event that is not a result but rather just an informative marker
@@ -389,6 +396,7 @@ impl SearchEventResult {
         match self.event_type {
             SearchEventType::START => serde_json::to_string(self).unwrap_or_default() + ",",
             SearchEventType::END => serde_json::to_string(self).unwrap_or_default(),
+            SearchEventType::MATCH => serde_json::to_string(self).unwrap_or_default() + ",",
         }
     }
 }
@@ -398,6 +406,9 @@ impl SearchEventResult {
 /// Note that `line_number` will be set only if [Args::line_number] is true when searching.
 #[derive(Debug, PartialEq, Clone, Serialize)]
 pub struct SearchResult {
+    /// The event type. This will always be [SearchEventType::MATCH].
+    pub event_type: SearchEventType,
+
     /// The path to the file containing the symbol definition
     pub file_path: String,
 
@@ -727,6 +738,7 @@ fn search_file_line_by_line(
             };
 
             Some(SearchResult {
+                event_type: SearchEventType::MATCH,
                 file_path: String::from(file_path),
                 line_number: if config.line_number {
                     Some(line_counter)

--- a/src/threads.rs
+++ b/src/threads.rs
@@ -23,7 +23,7 @@ impl Worker {
     ) -> Worker {
         let thread = thread::spawn(move || loop {
             // If the controller says to stop, ignore remaining jobs on the receiver and just stop.
-            if ! controller.is_empty() {
+            if !controller.is_empty() {
                 if debug {
                     println!("thread {}: {}", id, "Controller said to stop".red());
                 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -108,6 +108,7 @@ pub fn get_expected_text_line_for_test_search(
 pub fn get_expected_search_result_for_file_type(file_type_string: &str) -> SearchResult {
     let (text, line_number) = get_expected_text_line_for_test_search(file_type_string).unwrap();
     SearchResult {
+        event_type: grepdef::SearchEventType::MATCH,
         file_path: get_default_fixture_for_file_type_string(file_type_string).unwrap(),
         line_number: Some(line_number),
         text,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -31,7 +31,9 @@ pub fn do_search(args: Args) -> Vec<SearchResult> {
 pub fn do_search_callback(args: Args) -> Vec<SearchResult> {
     let searcher = Searcher::new(args).unwrap();
     let mut results = vec![];
-    searcher.search_callback(|l| results.push(l)).expect("Search failed for test");
+    searcher
+        .search_callback(|l| results.push(l))
+        .expect("Search failed for test");
     results
 }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -108,7 +108,7 @@ pub fn get_expected_text_line_for_test_search(
 pub fn get_expected_search_result_for_file_type(file_type_string: &str) -> SearchResult {
     let (text, line_number) = get_expected_text_line_for_test_search(file_type_string).unwrap();
     SearchResult {
-        event_type: grepdef::SearchEventType::MATCH,
+        event_type: grepdef::SearchEventType::NONE,
         file_path: get_default_fixture_for_file_type_string(file_type_string).unwrap(),
         line_number: Some(line_number),
         text,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -250,12 +250,14 @@ fn search_and_format_callback_provides_formatted_string_for_json_per_match_with_
     let query = String::from("parseQuery");
     let expected_result = common::get_expected_search_result_for_file_type("js");
     let expected = format!(
-        "{{\"file_path\":\"{}\",\"line_number\":null,\"text\":\"{}\"}}",
-        expected_result.file_path, expected_result.text
+        "{{\"file_path\":\"{}\",\"line_number\":{},\"text\":\"{}\"}}",
+        expected_result.file_path,
+        expected_result.line_number.unwrap(),
+        expected_result.text
     );
     let file_type_string = String::from("js");
     let mut args = common::make_args(query, Some(file_path), Some(file_type_string));
-    args.line_number = false;
+    args.line_number = true;
     args.no_color = true;
     args.format = Some(SearchResultFormat::JsonPerMatch);
     let actual = common::do_search_format_callback(args);
@@ -270,12 +272,14 @@ fn search_and_format_callback_provides_formatted_string_for_json_list_with_numbe
     let query = String::from("parseQuery");
     let expected_result = common::get_expected_search_result_for_file_type("js");
     let expected = format!(
-        "{{\"file_path\":\"{}\",\"line_number\":null,\"text\":\"{}\"}},",
-        expected_result.file_path, expected_result.text
+        "{{\"file_path\":\"{}\",\"line_number\":{},\"text\":\"{}\"}},",
+        expected_result.file_path,
+        expected_result.line_number.unwrap(),
+        expected_result.text
     );
     let file_type_string = String::from("js");
     let mut args = common::make_args(query, Some(file_path), Some(file_type_string));
-    args.line_number = false;
+    args.line_number = true;
     args.no_color = true;
     args.format = Some(SearchResultFormat::JsonList);
     let actual = common::do_search_format_callback(args);

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -208,7 +208,7 @@ fn search_and_format_returns_formatted_string_for_json_per_match_with_number() {
     let query = String::from("parseQuery");
     let expected_result = common::get_expected_search_result_for_file_type("js");
     let expected = format!(
-        "{{\"event_type\":\"MATCH\",\"file_path\":\"{}\",\"line_number\":{},\"text\":\"{}\"}}",
+        "{{\"file_path\":\"{}\",\"line_number\":{},\"text\":\"{}\"}}",
         expected_result.file_path,
         expected_result.line_number.unwrap(),
         expected_result.text
@@ -230,7 +230,7 @@ fn search_and_format_returns_formatted_string_for_json_per_match_without_number(
     let query = String::from("parseQuery");
     let expected_result = common::get_expected_search_result_for_file_type("js");
     let expected = format!(
-        "{{\"event_type\":\"MATCH\",\"file_path\":\"{}\",\"line_number\":null,\"text\":\"{}\"}}",
+        "{{\"file_path\":\"{}\",\"line_number\":null,\"text\":\"{}\"}}",
         expected_result.file_path, expected_result.text
     );
     let file_type_string = String::from("js");
@@ -250,7 +250,7 @@ fn search_and_format_callback_provides_formatted_string_for_json_per_match_with_
     let query = String::from("parseQuery");
     let expected_result = common::get_expected_search_result_for_file_type("js");
     let expected = format!(
-        "{{\"event_type\":\"MATCH\",\"file_path\":\"{}\",\"line_number\":{},\"text\":\"{}\"}}",
+        "{{\"file_path\":\"{}\",\"line_number\":{},\"text\":\"{}\"}}",
         expected_result.file_path,
         expected_result.line_number.unwrap(),
         expected_result.text
@@ -573,7 +573,7 @@ fn search_returns_matching_php_function_line_guessing_file_type_from_directory()
     let query = String::from("otherPhpFunction");
     let line_number = Some(3);
     let expected = vec![SearchResult {
-        event_type: grepdef::SearchEventType::MATCH,
+        event_type: grepdef::SearchEventType::NONE,
         file_path: file_path.clone(),
         line_number,
         text: String::from("function otherPhpFunction() {"),

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -175,6 +175,34 @@ fn search_and_format_returns_formatted_string_for_grep_without_number() {
 }
 
 #[rstest]
+fn search_and_format_returns_formatted_string_for_json_list_with_number() {
+    let file_path = common::get_default_fixture_for_file_type_string("js").unwrap();
+    let query = String::from("parseQuery");
+    let expected_result = common::get_expected_search_result_for_file_type("js");
+    let expected = format!(
+        "{{\"file_path\":\"{}\",\"line_number\":{},\"text\":\"{}\"}},",
+        expected_result.file_path,
+        expected_result.line_number.unwrap(),
+        expected_result.text
+    );
+    let file_type_string = String::from("js");
+    let mut args = common::make_args(query, Some(file_path), Some(file_type_string));
+    args.line_number = true;
+    args.no_color = true;
+    args.format = Some(SearchResultFormat::JsonList);
+    let actual = common::do_search_format(args);
+    for (i, result) in actual.iter().enumerate() {
+        match i {
+            0 => assert_eq!("[", String::from(result)),
+            1 => assert_eq!("{\"event_type\":\"START\"},", String::from(result)),
+            3 => assert_eq!("{\"event_type\":\"END\"}", String::from(result)),
+            4 => assert_eq!("]", String::from(result)),
+            _ => assert_eq!(expected, String::from(result)),
+        }
+    }
+}
+
+#[rstest]
 fn search_and_format_returns_formatted_string_for_json_per_match_with_number() {
     let file_path = common::get_default_fixture_for_file_type_string("js").unwrap();
     let query = String::from("parseQuery");
@@ -235,6 +263,33 @@ fn search_and_format_callback_provides_formatted_string_for_json_per_match_with_
         assert_eq!(expected, result);
     }
 }
+
+#[rstest]
+fn search_and_format_callback_provides_formatted_string_for_json_list_with_number() {
+    let file_path = common::get_default_fixture_for_file_type_string("js").unwrap();
+    let query = String::from("parseQuery");
+    let expected_result = common::get_expected_search_result_for_file_type("js");
+    let expected = format!(
+        "{{\"file_path\":\"{}\",\"line_number\":null,\"text\":\"{}\"}},",
+        expected_result.file_path, expected_result.text
+    );
+    let file_type_string = String::from("js");
+    let mut args = common::make_args(query, Some(file_path), Some(file_type_string));
+    args.line_number = false;
+    args.no_color = true;
+    args.format = Some(SearchResultFormat::JsonList);
+    let actual = common::do_search_format_callback(args);
+    for (i, result) in actual.iter().enumerate() {
+        match i {
+            0 => assert_eq!("[", String::from(result)),
+            1 => assert_eq!("{\"event_type\":\"START\"},", String::from(result)),
+            3 => assert_eq!("{\"event_type\":\"END\"}", String::from(result)),
+            4 => assert_eq!("]", String::from(result)),
+            _ => assert_eq!(expected, String::from(result)),
+        }
+    }
+}
+
 
 #[rstest]
 fn search_returns_matching_js_function_line_with_two_files() {
@@ -410,13 +465,17 @@ fn search_returns_expected_line_number_for_file_type(
 fn search_returns_expected_line_number_group_for_file_type(
     #[case] query: String,
     #[case] file_type_string: String,
-    #[case] line_numbers: [usize;3],
+    #[case] line_numbers: [usize; 3],
 ) {
     let file_path =
         common::get_default_fixture_for_file_type_string(file_type_string.as_str()).unwrap();
     let args = common::make_args(query, Some(file_path), Some(file_type_string));
     let actual = common::do_search(args);
-    assert_eq!(line_numbers.len(), actual.len(), "Did not find expected number of matches");
+    assert_eq!(
+        line_numbers.len(),
+        actual.len(),
+        "Did not find expected number of matches"
+    );
     for (i, result) in actual.iter().enumerate() {
         assert_eq!(
             line_numbers[i],
@@ -433,7 +492,7 @@ fn search_returns_expected_line_number_group_for_file_type(
 fn search_returns_limited_expected_line_number_group_for_file_type(
     #[case] query: String,
     #[case] file_type_string: String,
-    #[case] line_numbers: [usize;3],
+    #[case] line_numbers: [usize; 3],
     #[case] limit: usize,
 ) {
     let file_path =
@@ -441,7 +500,11 @@ fn search_returns_limited_expected_line_number_group_for_file_type(
     let mut args = common::make_args(query, Some(file_path), Some(file_type_string));
     args.limit = Some(limit);
     let actual = common::do_search(args);
-    assert_eq!(limit, actual.len(), "Did not find expected number of matches");
+    assert_eq!(
+        limit,
+        actual.len(),
+        "Did not find expected number of matches"
+    );
     for (i, result) in actual.iter().enumerate() {
         assert_eq!(
             line_numbers[i],

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -180,7 +180,7 @@ fn search_and_format_returns_formatted_string_for_json_list_with_number() {
     let query = String::from("parseQuery");
     let expected_result = common::get_expected_search_result_for_file_type("js");
     let expected = format!(
-        "{{\"file_path\":\"{}\",\"line_number\":{},\"text\":\"{}\"}},",
+        "{{\"event_type\":\"MATCH\",\"file_path\":\"{}\",\"line_number\":{},\"text\":\"{}\"}},",
         expected_result.file_path,
         expected_result.line_number.unwrap(),
         expected_result.text
@@ -208,7 +208,7 @@ fn search_and_format_returns_formatted_string_for_json_per_match_with_number() {
     let query = String::from("parseQuery");
     let expected_result = common::get_expected_search_result_for_file_type("js");
     let expected = format!(
-        "{{\"file_path\":\"{}\",\"line_number\":{},\"text\":\"{}\"}}",
+        "{{\"event_type\":\"MATCH\",\"file_path\":\"{}\",\"line_number\":{},\"text\":\"{}\"}}",
         expected_result.file_path,
         expected_result.line_number.unwrap(),
         expected_result.text
@@ -230,7 +230,7 @@ fn search_and_format_returns_formatted_string_for_json_per_match_without_number(
     let query = String::from("parseQuery");
     let expected_result = common::get_expected_search_result_for_file_type("js");
     let expected = format!(
-        "{{\"file_path\":\"{}\",\"line_number\":null,\"text\":\"{}\"}}",
+        "{{\"event_type\":\"MATCH\",\"file_path\":\"{}\",\"line_number\":null,\"text\":\"{}\"}}",
         expected_result.file_path, expected_result.text
     );
     let file_type_string = String::from("js");
@@ -250,7 +250,7 @@ fn search_and_format_callback_provides_formatted_string_for_json_per_match_with_
     let query = String::from("parseQuery");
     let expected_result = common::get_expected_search_result_for_file_type("js");
     let expected = format!(
-        "{{\"file_path\":\"{}\",\"line_number\":{},\"text\":\"{}\"}}",
+        "{{\"event_type\":\"MATCH\",\"file_path\":\"{}\",\"line_number\":{},\"text\":\"{}\"}}",
         expected_result.file_path,
         expected_result.line_number.unwrap(),
         expected_result.text
@@ -272,7 +272,7 @@ fn search_and_format_callback_provides_formatted_string_for_json_list_with_numbe
     let query = String::from("parseQuery");
     let expected_result = common::get_expected_search_result_for_file_type("js");
     let expected = format!(
-        "{{\"file_path\":\"{}\",\"line_number\":{},\"text\":\"{}\"}},",
+        "{{\"event_type\":\"MATCH\",\"file_path\":\"{}\",\"line_number\":{},\"text\":\"{}\"}},",
         expected_result.file_path,
         expected_result.line_number.unwrap(),
         expected_result.text
@@ -293,7 +293,6 @@ fn search_and_format_callback_provides_formatted_string_for_json_list_with_numbe
         }
     }
 }
-
 
 #[rstest]
 fn search_returns_matching_js_function_line_with_two_files() {
@@ -574,6 +573,7 @@ fn search_returns_matching_php_function_line_guessing_file_type_from_directory()
     let query = String::from("otherPhpFunction");
     let line_number = Some(3);
     let expected = vec![SearchResult {
+        event_type: grepdef::SearchEventType::MATCH,
         file_path: file_path.clone(),
         line_number,
         text: String::from("function otherPhpFunction() {"),


### PR DESCRIPTION
This PR adds the `--format json-list` option. This is similar to `json-per-match`, but there are some significant differences. First of all, the entire output is a valid JSON document: an array of events. Second, each event has a `event_type` property. For results, this will always be `"MATCH"`, but there are also special `"START"` and `"END"` events.

Here's the result of grepdef with `--format json-per-match`:

```json
{
  "file_path": "tests/fixtures/by-language/php-fixture.php",
  "line_number": 48,
  "text": "public function similarMethod() {}"
}
{
  "file_path": "tests/fixtures/by-language/php-fixture.php",
  "line_number": 51,
  "text": "public function similarMethod() {}"
}
{
  "file_path": "tests/fixtures/by-language/php-fixture.php",
  "line_number": 54,
  "text": "public function similarMethod() {}"
}
```

And here's the same output with `--format json-list`:

```json
[
  {
    "event_type": "START"
  },
  {
    "event_type": "MATCH",
    "file_path": "tests/fixtures/by-language/php-fixture.php",
    "line_number": 48,
    "text": "public function similarMethod() {}"
  },
  {
    "event_type": "MATCH",
    "file_path": "tests/fixtures/by-language/php-fixture.php",
    "line_number": 51,
    "text": "public function similarMethod() {}"
  },
  {
    "event_type": "MATCH",
    "file_path": "tests/fixtures/by-language/php-fixture.php",
    "line_number": 54,
    "text": "public function similarMethod() {}"
  },
  {
    "event_type": "END"
  }
]
```