### PR TITLE
Stop using regex for file type detection

### DIFF
--- a/src/file_type.rs
+++ b/src/file_type.rs
@@ -5,21 +5,20 @@ use regex::Regex;
 use std::fs;
 use std::io::Read;
 
-pub fn get_regexp_for_file_type(file_type: &FileType) -> Regex {
-    let regexp_string = match file_type {
-        FileType::JS => &r"\.(:?js|jsx|ts|tsx|mjs|cjs)$".to_string(),
-        FileType::PHP => &r"\.php$".to_string(),
-        FileType::RS => &r"\.rs$".to_string(),
-        FileType::PY => &r"\.py$".to_string(),
-    };
-    Regex::new(regexp_string).expect("Could not create regex for file extension")
+pub fn path_matches_file_type(path: &str, file_type: &FileType) -> bool {
+    let ext = std::path::Path::new(path)
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("");
+    match file_type {
+        FileType::JS => matches!(ext, "js" | "jsx" | "ts" | "tsx" | "mjs" | "cjs"),
+        FileType::PHP => ext == "php",
+        FileType::RS => ext == "rs",
+        FileType::PY => ext == "py",
+    }
 }
 
 pub fn guess_file_type_from_file_path(file_path: &str) -> Option<FileType> {
-    let js_regex = get_regexp_for_file_type(&FileType::JS);
-    let php_regex = get_regexp_for_file_type(&FileType::PHP);
-    let rs_regex = get_regexp_for_file_type(&FileType::RS);
-    let py_regex = get_regexp_for_file_type(&FileType::PY);
     for entry in Walk::new(file_path) {
         let path = match entry {
             Ok(path) => path.into_path(),
@@ -28,21 +27,16 @@ pub fn guess_file_type_from_file_path(file_path: &str) -> Option<FileType> {
         if path.is_dir() {
             continue;
         }
-        let path = match path.to_str() {
-            Some(p) => p.to_string(),
-            None => String::from(""),
-        };
-        if js_regex.is_match(&path) {
-            return Some(FileType::JS);
-        }
-        if php_regex.is_match(&path) {
-            return Some(FileType::PHP);
-        }
-        if rs_regex.is_match(&path) {
-            return Some(FileType::RS);
-        }
-        if py_regex.is_match(&path) {
-            return Some(FileType::PY);
+        let ext = path
+            .extension()
+            .and_then(|e| e.to_str())
+            .unwrap_or("");
+        match ext {
+            "js" | "jsx" | "ts" | "tsx" | "mjs" | "cjs" => return Some(FileType::JS),
+            "php" => return Some(FileType::PHP),
+            "rs" => return Some(FileType::RS),
+            "py" => return Some(FileType::PY),
+            _ => continue,
         }
     }
     None

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -568,7 +568,6 @@ impl Searcher {
             None
         };
         let re = query_regex::get_regex_for_query(&self.config.query, &self.config.file_type);
-        let file_type_re = file_type::get_regexp_for_file_type(&self.config.file_type);
         let mut pool = threads::ThreadPool::new(self.config.num_threads, self.config.debug);
 
         match self.config.color {
@@ -604,7 +603,7 @@ impl Searcher {
                             return Err(Box::from("Error getting string from path"));
                         }
                     };
-                    if !file_type_re.is_match(&path) {
+                    if !file_type::path_matches_file_type(&path, &self.config.file_type) {
                         continue;
                     }
                     searched_file_count += 1;


### PR DESCRIPTION
This changes to use simple file path matching instead of Regex for file type detection. This should be much faster.
