### PR TITLE
Several performance improvements

### DIFF
--- a/src/file_type.rs
+++ b/src/file_type.rs
@@ -53,13 +53,12 @@ pub fn does_file_match_regexp(mut file: &fs::File, re: &Regex) -> bool {
     re.is_match(&buf)
 }
 
-pub fn does_file_match_query(mut file: &fs::File, query: &str) -> bool {
+pub fn does_file_match_query(mut file: &fs::File, finder: &memmem::Finder<'_>) -> bool {
     let mut full: Vec<u8> = vec![];
     let mut buf = [0u8; 2048];
-    let finder = memmem::Finder::new(query);
-    // Keep query.len()-1 bytes of overlap between chunks so matches that
+    // Keep needle.len()-1 bytes of overlap between chunks so matches that
     // span a chunk boundary are not missed.
-    let overlap = query.len().saturating_sub(1);
+    let overlap = finder.needle().len().saturating_sub(1);
     loop {
         let n = file.read(&mut buf).unwrap_or(0);
         if n == 0 {

--- a/src/file_type.rs
+++ b/src/file_type.rs
@@ -57,18 +57,20 @@ pub fn does_file_match_query(mut file: &fs::File, query: &str) -> bool {
     let mut full: Vec<u8> = vec![];
     let mut buf = [0u8; 2048];
     let finder = memmem::Finder::new(query);
+    // Keep query.len()-1 bytes of overlap between chunks so matches that
+    // span a chunk boundary are not missed.
+    let overlap = query.len().saturating_sub(1);
     loop {
-        let bytes = file.read(&mut buf);
-        if bytes.unwrap_or(0) == 0 {
+        let n = file.read(&mut buf).unwrap_or(0);
+        if n == 0 {
             break false;
         }
-        if full.contains(&0xA) {
-            let mut split_full = full.rsplit(|&b| b == b'\n');
-            full = split_full.next().unwrap_or(&[0u8, 1]).to_vec();
-        }
-        full.extend(buf);
+        full.extend_from_slice(&buf[..n]);
         if finder.find(&full).is_some() {
             break true;
+        }
+        if full.len() > overlap {
+            full.drain(..full.len() - overlap);
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,7 +237,7 @@ impl Config {
 
         let num_threads = match args.threads {
             Some(threads) => threads,
-            None => NonZero::new(5).expect("Default number of threads was invalid"),
+            None => std::thread::available_parallelism().unwrap_or(NonZero::new(5).unwrap()),
         };
 
         let config = Config {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@
 use clap::Parser;
 use colored::Colorize;
 use ignore::{WalkBuilder, WalkState};
+use memchr::memmem;
 use regex::Regex;
 use serde::Serialize;
 use std::error::Error;
@@ -620,6 +621,8 @@ impl Searcher {
                     let config = Arc::clone(&config_walk);
                     let should_quit = Arc::clone(&should_quit_walk);
                     let searched_file_count = Arc::clone(&searched_file_count_walk);
+                    // Build the memmem Finder once per thread rather than once per file.
+                    let finder = memmem::Finder::new(config.query.as_bytes()).into_owned();
 
                     Box::new(move |entry| {
                         if should_quit.load(Ordering::Relaxed) {
@@ -641,7 +644,7 @@ impl Searcher {
                         }
                         searched_file_count.fetch_add(1, Ordering::Relaxed);
                         let tx_file = tx.clone();
-                        search_file(&re, &path_str, &config, move |results| {
+                        search_file(&re, &path_str, &config, &finder, move |results| {
                             let _ = tx_file.send(results);
                         });
                         WalkState::Continue
@@ -712,7 +715,7 @@ fn debug(config: &Config, output: &str) {
     }
 }
 
-fn search_file<F>(re: &Regex, file_path: &str, config: &Config, callback: F)
+fn search_file<F>(re: &Regex, file_path: &str, config: &Config, finder: &memmem::Finder<'_>, callback: F)
 where
     F: FnOnce(Vec<SearchResult>) + Send + 'static,
 {
@@ -726,7 +729,7 @@ where
             if match config.search_method {
                 SearchMethod::PrescanRegex => !file_type::does_file_match_regexp(&file, re),
                 SearchMethod::PrescanMemmem => {
-                    !file_type::does_file_match_query(&file, &config.query)
+                    !file_type::does_file_match_query(&file, finder)
                 }
                 SearchMethod::NoPrescan => false,
             } {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -765,7 +765,8 @@ fn search_file_line_by_line(
     file: &fs::File,
     config: &Config,
 ) -> Vec<SearchResult> {
-    let lines = io::BufReader::new(file).lines();
+    // 64 KB buffer reduces syscalls by up to 8x compared to the default 8 KB.
+    let lines = io::BufReader::with_capacity(64 * 1024, file).lines();
     let mut line_counter = 0;
 
     lines


### PR DESCRIPTION
This implements several smaller performance improvements. The biggest of which is increasing the number of default threads.

- **Default number of threads to system amount**
- **Fix performance bugs with does_file_match_query**
- **Increase BufReader size**
- **Only create `Finder` once**

## Stats

On a 4.0G codebase with no explicit threads and a cold cache on a M1 Macbook Pro.

Before:

```
$ hyperfine --prepare 'sync; sudo purge' 'grepdef WPCOM_JSON_API_New_User_Endpoint'
Benchmark 1: grepdef WPCOM_JSON_API_New_User_Endpoint
  Time (mean ± σ):      3.334 s ±  0.091 s    [User: 0.702 s, System: 5.166 s]
  Range (min … max):    3.164 s …  3.447 s    10 runs
```

After:

```
$ hyperfine --prepare 'sync; sudo purge' 'grepdef WPCOM_JSON_API_New_User_Endpoint'
Benchmark 1: grepdef WPCOM_JSON_API_New_User_Endpoint
  Time (mean ± σ):      2.634 s ±  0.091 s    [User: 0.918 s, System: 9.316 s]
  Range (min … max):    2.425 s …  2.783 s    10 runs
```
