### PR TITLE
Use memory mapping to read files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,6 +308,7 @@ dependencies = [
  "exitcode",
  "ignore",
  "memchr",
+ "memmap2",
  "regex",
  "rstest",
  "serde",
@@ -373,6 +374,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "libc"
+version = "0.2.183"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
 name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -383,6 +390,15 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "pin-project-lite"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ crossbeam-channel = "0.5.15"
 exitcode = "1.1.2"
 ignore = "0.4.22"
 memchr = "2.7.4"
+memmap2 = "0.9"
 regex = "1.10.5"
 rstest = "0.21.0"
 serde = { version = "1.0.204", features = ["derive"] }

--- a/src/file_type.rs
+++ b/src/file_type.rs
@@ -1,9 +1,5 @@
 use super::FileType;
 use ignore::Walk;
-use memchr::memmem;
-use regex::Regex;
-use std::fs;
-use std::io::Read;
 
 pub fn path_matches_file_type(path: &str, file_type: &FileType) -> bool {
     let ext = std::path::Path::new(path)
@@ -42,34 +38,4 @@ pub fn guess_file_type_from_file_path(file_path: &str) -> Option<FileType> {
         }
     }
     None
-}
-
-pub fn does_file_match_regexp(mut file: &fs::File, re: &Regex) -> bool {
-    let mut buf = String::new();
-    let bytes = file.read_to_string(&mut buf);
-    if bytes.unwrap_or(0) == 0 {
-        return false;
-    }
-    re.is_match(&buf)
-}
-
-pub fn does_file_match_query(mut file: &fs::File, finder: &memmem::Finder<'_>) -> bool {
-    let mut full: Vec<u8> = vec![];
-    let mut buf = [0u8; 2048];
-    // Keep needle.len()-1 bytes of overlap between chunks so matches that
-    // span a chunk boundary are not missed.
-    let overlap = finder.needle().len().saturating_sub(1);
-    loop {
-        let n = file.read(&mut buf).unwrap_or(0);
-        if n == 0 {
-            break false;
-        }
-        full.extend_from_slice(&buf[..n]);
-        if finder.find(&full).is_some() {
-            break true;
-        }
-        if full.len() > overlap {
-            full.drain(..full.len() - overlap);
-        }
-    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ use colored::Colorize;
 use ignore::{WalkBuilder, WalkState};
 use memchr::memmem;
 use memmap2::MmapOptions;
-use regex::Regex;
+use regex::bytes::Regex;
 use serde::Serialize;
 use std::error::Error;
 use std::fs;
@@ -744,9 +744,7 @@ where
     // Prescan: quickly reject files that definitely don't contain a match.
     let prescan_pass = match config.search_method {
         SearchMethod::PrescanMemmem => finder.find(bytes).is_some(),
-        SearchMethod::PrescanRegex => {
-            std::str::from_utf8(bytes).map_or(false, |s| re.is_match(s))
-        }
+        SearchMethod::PrescanRegex => re.is_match(bytes),
         SearchMethod::NoPrescan => true,
     };
 
@@ -782,11 +780,12 @@ fn search_file_line_by_line(
         .split(|&b| b == b'\n')
         .filter_map(|line_bytes| {
             line_counter += 1;
-            // Skip lines that aren't valid UTF-8 (e.g. binary content).
-            let line = std::str::from_utf8(line_bytes).ok()?;
-            if !re.is_match(line) {
+            if !re.is_match(line_bytes) {
                 return None;
             }
+            // Only validate UTF-8 for lines that matched — since matches are rare,
+            // this avoids validating the entire file byte-by-byte.
+            let line = std::str::from_utf8(line_bytes).ok()?;
             Some(SearchResult {
                 event_type: match config.format {
                     SearchResultFormat::JsonList => SearchEventType::MATCH,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,11 +52,11 @@ use clap::Parser;
 use colored::Colorize;
 use ignore::{WalkBuilder, WalkState};
 use memchr::memmem;
+use memmap2::MmapOptions;
 use regex::Regex;
 use serde::Serialize;
 use std::error::Error;
 use std::fs;
-use std::io::{self, BufRead, Seek};
 use std::num::NonZero;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{mpsc, Arc};
@@ -720,75 +720,73 @@ where
     F: FnOnce(Vec<SearchResult>) + Send + 'static,
 {
     debug(config, format!("Scanning file {}", file_path).as_str());
-    let file = fs::File::open(file_path);
-
-    match file {
-        Ok(mut file) => {
-            // Scan the file in big chunks to see if it has what we are looking for. This is more efficient
-            // than going line-by-line on every file since matches should be quite rare.
-            if match config.search_method {
-                SearchMethod::PrescanRegex => !file_type::does_file_match_regexp(&file, re),
-                SearchMethod::PrescanMemmem => {
-                    !file_type::does_file_match_query(&file, finder)
-                }
-                SearchMethod::NoPrescan => false,
-            } {
-                debug(
-                    config,
-                    format!("Presearch of {} found no match; skipping", &file_path).as_str(),
-                );
-                callback(vec![]);
-                return;
-            }
-
-            let rewind_result = file.rewind();
-            if rewind_result.is_err() {
-                callback(vec![]);
-                return;
-            }
-            debug(
-                config,
-                format!(
-                    "Presearch of {} was successful; searching for line",
-                    &file_path
-                )
-                .as_str(),
-            );
-            callback(search_file_line_by_line(re, file_path, &file, config));
-        }
+    let file = match fs::File::open(file_path) {
+        Ok(f) => f,
         Err(_) => {
             callback(vec![]);
+            return;
         }
+    };
+
+    // Memory-map the file so the OS page cache is used directly — no explicit read() calls,
+    // no intermediate buffer allocation, and no rewind needed between prescan and line search.
+    // SAFETY: we only read from the mapping and never modify the file during the search.
+    let mmap = match unsafe { MmapOptions::new().map(&file) } {
+        Ok(m) => m,
+        // mmap fails on empty files and in rare resource-exhaustion cases; just skip.
+        Err(_) => {
+            callback(vec![]);
+            return;
+        }
+    };
+    let bytes: &[u8] = &mmap;
+
+    // Prescan: quickly reject files that definitely don't contain a match.
+    let prescan_pass = match config.search_method {
+        SearchMethod::PrescanMemmem => finder.find(bytes).is_some(),
+        SearchMethod::PrescanRegex => {
+            std::str::from_utf8(bytes).map_or(false, |s| re.is_match(s))
+        }
+        SearchMethod::NoPrescan => true,
+    };
+
+    if !prescan_pass {
+        debug(
+            config,
+            format!("Presearch of {} found no match; skipping", &file_path).as_str(),
+        );
+        callback(vec![]);
+        return;
     }
+
+    debug(
+        config,
+        format!(
+            "Presearch of {} was successful; searching for line",
+            &file_path
+        )
+        .as_str(),
+    );
+    callback(search_file_line_by_line(re, file_path, bytes, config));
 }
 
 fn search_file_line_by_line(
     re: &Regex,
     file_path: &str,
-    file: &fs::File,
+    bytes: &[u8],
     config: &Config,
 ) -> Vec<SearchResult> {
-    // 64 KB buffer reduces syscalls by up to 8x compared to the default 8 KB.
-    let lines = io::BufReader::with_capacity(64 * 1024, file).lines();
     let mut line_counter = 0;
 
-    lines
-        .filter_map(|line| {
+    bytes
+        .split(|&b| b == b'\n')
+        .filter_map(|line_bytes| {
             line_counter += 1;
-            if !match &line {
-                Ok(line) => re.is_match(line),
-                Err(_) => false,
-            } {
+            // Skip lines that aren't valid UTF-8 (e.g. binary content).
+            let line = std::str::from_utf8(line_bytes).ok()?;
+            if !re.is_match(line) {
                 return None;
             }
-
-            let text = match line {
-                Ok(line) => line,
-                // If reading the line causes an error (eg: invalid UTF), then skip it by treating
-                // it as empty.
-                Err(_err) => String::from(""),
-            };
-
             Some(SearchResult {
                 event_type: match config.format {
                     SearchResultFormat::JsonList => SearchEventType::MATCH,
@@ -800,7 +798,7 @@ fn search_file_line_by_line(
                 } else {
                     None
                 },
-                text: text.trim().into(),
+                text: line.trim().into(),
             })
         })
         .collect()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,10 +167,10 @@ impl Args {
 #[derive(clap::ValueEnum, Clone, Default, Debug, EnumString, PartialEq, Display)]
 pub enum SearchMethod {
     /// Pre-scan each file by reading fully into memory and using a Regex
-    #[default]
     PrescanRegex,
 
     /// Pre-scan each file by reading bytes until the query is found using memmem
+    #[default]
     PrescanMemmem,
 
     /// Don't pre-scan files.

--- a/src/query_regex.rs
+++ b/src/query_regex.rs
@@ -1,5 +1,5 @@
 use super::FileType;
-use regex::Regex;
+use regex::bytes::Regex;
 
 pub fn get_regex_for_query(query: &str, file_type: &FileType) -> Regex {
     let regexp_string = match file_type {


### PR DESCRIPTION
This PR switches file reading (during prescan and main scan) to use memory mapping. We use the `memmap2` package which memory-maps a file, meaning the OS maps the file's contents directly into the process's virtual address space. Instead of calling `read()` to copy bytes from kernel space into a user-space buffer, you get a pointer to the file's data and access it like a slice. The OS pages data in lazily from disk as you touch it which should be much more efficient.

We also switch to using `PrescanMemmem` as the default prescan method since it should also be much more efficient for relatively unique symbols (which is hopefully most searches), prescanning files by bytes instead of with a regex. I haven't noticed a big benefit in performance myself but also no worse performance.